### PR TITLE
Add conf-tree-sitter to tree-sitter.opam

### DIFF
--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -25,6 +25,7 @@ depends: [
   "ppx_sexp_conv"
   "sexplib"
   "tsort" {>= "2.0"}
+  "conf-tree-sitter"
 ]
 
 synopsis: "Code generator for parsing the output of tree-sitter parsers"


### PR DESCRIPTION
With this we should be able to guarantee that tree-sitter is installed and even install it with `opam depext`