### PR TITLE
Allow semgrep scan on external pull requests (maybe)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
     - main


### PR DESCRIPTION
Trying to see if 'pull_request_target' allows running the semgrep job on pull requests from forked repos. Imitating https://github.com/returntocorp/semgrep/pull/3464