### PR TITLE
adding regex project and deleting kotlin lang

### DIFF
--- a/lang/kotlin/projects.txt
+++ b/lang/kotlin/projects.txt
@@ -1,4 +1,3 @@
-https://github.com/JetBrains/kotlin
 https://github.com/hussien89aa/KotlinUdemy
 https://github.com/git-xuhao/KotlinMvp
 https://github.com/Kotlin/kotlin-koans
@@ -28,3 +27,4 @@ https://github.com/detekt/detekt
 https://github.com/Kotlin/kotlinx.serialization
 https://github.com/perwendel/spark
 https://github.com/gradle/kotlin-dsl-samples
+https://github.com/noxone/regex-generator


### PR DESCRIPTION
* deleting jetbrains/kotlin because the project uses self-made test patterns that have not been seen in other projects. The self-created test patterns usually do not parse well with the current ocaml-tree-sitter kotlin grammar.