### PR TITLE
Warn against Blank nodes during test-lang

### DIFF
--- a/lang/test-lang
+++ b/lang/test-lang
@@ -72,6 +72,27 @@ if [[ "$lang" = typescript ]]; then
   sublangs="typescript tsx"
 fi
 
+check_for_blanks() {
+  cst_ml=ocaml-src/lib/CST.ml
+  if grep -C 2 Blank "$cst_ml"; then
+    cat 2>&1 <<EOF
+
+found in $(pwd)/$cst_ml
+language: $sublang
+
+*** Warning: We have some Blank nodes, which will produce no tokens. ***
+
+This means there won't be any token or location information available
+at parsing time for these nodes.
+
+You should get back to the grammar and create named rules for these nodes
+to avoid this problem.
+EOF
+    else
+      echo "$sublang: OK"
+  fi
+}
+
 echo "Testing C/OCaml code generation for sublanguages: $sublangs"
 for sublang in $sublangs; do
   (
@@ -79,5 +100,13 @@ for sublang in $sublangs; do
     make clean
     make
     make test
+  )
+done
+
+for sublang in $sublangs; do
+  (
+    echo "$sublang: Checking for undesirable Blank nodes."
+    cd "$sublang"
+    check_for_blanks
   )
 done


### PR DESCRIPTION
I [added this to the documentation](https://github.com/returntocorp/ocaml-tree-sitter-semgrep/blob/main/doc/updating-a-grammar.md#testing) earlier and figured this check would be better automated.

The affected languages are currently:
* C (c)
* C++ (cpp)
* go
* hcl

cc @Sjord who suffered from this before with the C# grammar.