### PR TITLE
add extension: .hcl

### DIFF
--- a/lang/hcl/extensions.txt
+++ b/lang/hcl/extensions.txt
@@ -1,2 +1,3 @@
 # File extensions for the HCL language
 .tf
+.hcl


### PR DESCRIPTION
Several applications other than Terraform use HCL (both other HashiCorp apps and non-hashi, e.g. Terragrunt)