### PR TITLE
[Hack] Extend statements and expressions with ellipsis

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-hack/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-hack/grammar.js
@@ -13,23 +13,58 @@ const base_grammar = require('tree-sitter-hacklang/grammar');
 module.exports = grammar(base_grammar, {
   name: 'hack',
 
-  conflicts: ($, previous) => previous.concat([
-  ]),
+  conflicts: ($, previous) => previous.concat([]),
 
-  /*
-     Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
-     if they're not already part of the base grammar.
-  */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
+    /*
+      Support for semgrep ellipsis ('...')
+    */
+
+    // For now, we give precedence to native ellipsis (aka variadic modifiers).
+    ellipsis: ($) => prec(-1, '...'),
+    deep_ellipsis: ($) => prec(-1, seq('<...', $._expression, '...>')),
+
+    // By using an empty statement, we leverage a statement type that is strictly only used within
+    // $._statement and nowhere else.
+    empty_statement: ($, previous) => {
+      return choice(
+        previous,
+        // For conflict with `ellipsis;`
+        // we want it to be read as an expression with a semicolon
+        // instead of a statement
+        prec(-1, $.ellipsis) // statement ellipsis
+      );
+    },
 
     _expression: ($, previous) => {
-      return choice(
-        $.semgrep_ellipsis,
-        ...previous.members
+      return choice(previous, $.ellipsis, $.deep_ellipsis);
+    },
+
+    member_declarations: ($) => {
+      return seq(
+        '{',
+        choice.rep(
+          // Copied from existing grammar
+          alias($._class_const_declaration, $.const_declaration),
+          $.method_declaration,
+          $.property_declaration,
+          $.type_const_declaration,
+          $.trait_use_clause,
+          $.require_implements_clause,
+          $.require_extends_clause,
+          $.xhp_attribute_declaration,
+          $.xhp_children_declaration,
+          $.xhp_category_declaration,
+
+          // Additions
+          $.ellipsis
+        ),
+        '}'
       );
-    }
-  */
-  }
+    },
+
+    parameter: ($, previous) => {
+      return choice(previous, $.ellipsis);
+    },
+  },
 });

--- a/lang/semgrep-grammars/src/semgrep-hack/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-hack/grammar.js
@@ -10,6 +10,31 @@
 //
 const base_grammar = require('tree-sitter-hacklang/grammar');
 
+// BEGIN: Helper functions copied from tree-sitter-hack.
+
+/**
+ * Comma separated rules. A ',' as the last argument indicates an optional trailing comma.
+ */
+function com(...rules) {
+  if (rules[rules.length - 1] == ',') {
+    rules.splice(-1, 1);
+    return seq(...rules, repeat(seq(',', ...rules)), optional(','));
+  } else {
+    return seq(...rules, repeat(seq(',', ...rules)));
+  }
+}
+
+[seq, choice, alias, com].forEach((func) => {
+  func.opt = (...args) => optional(func(...args));
+  func.rep = (...args) => repeat(func(...args));
+  func.rep1 = (...args) => repeat1(func(...args));
+});
+
+const opt = optional;
+const rep = repeat;
+
+// END: Helper functions copied from tree-sitter-hack.
+
 module.exports = grammar(base_grammar, {
   name: 'hack',
 
@@ -66,5 +91,158 @@ module.exports = grammar(base_grammar, {
     parameter: ($, previous) => {
       return choice(previous, $.ellipsis);
     },
+
+    /*
+      Support for semgrep metavariables ('$FOO')
+    */
+
+    semgrep_identifier: ($) => /\$[A-Z_][A-Z_0-9]*/,
+    _semgrep_extended_identifier: ($) =>
+      choice($.semgrep_identifier, $.identifier),
+
+    // Normally, we would hope to extend $.identifier to support
+    // the $ prefix. However, this causes conflicts with Hack
+    // variable syntax. So, we manually add the semgrep semgrep_identifier
+    // where want to support it.
+    // TODO: Continue adding language constructs where we want to support
+    // metavariable overrides (like in XHP). Or get global $.identifier
+    // extension working.
+
+    qualified_identifier: ($, previous) => {
+      return choice(previous, $.semgrep_identifier);
+    },
+
+    // Alternative reach-in edit strategy:
+    /*
+    _function_declaration_header: ($, previous) => {
+      // Overriding name field
+      previous.members[2]['content'] = choice(
+        $.identifier,
+        $._semgrep_identifier
+      );
+      return previous;
+    },
+    */
+
+    alias_declaration: ($) =>
+      seq(
+        opt($.attribute_modifier),
+        choice('type', 'newtype'),
+        $._semgrep_extended_identifier, // Overridden
+        opt($.type_parameters),
+        field('as', seq.opt('as', $._type)),
+        '=',
+        $._type,
+        ';'
+      ),
+
+    _function_declaration_header: ($) =>
+      seq(
+        opt($.async_modifier),
+        'function',
+        field('name', $._semgrep_extended_identifier), // Overridden
+        opt($.type_parameters),
+        $.parameters,
+        seq.opt(':', opt($.attribute_modifier), field('return_type', $._type)),
+        opt($.where_clause)
+      ),
+
+    trait_declaration: ($) =>
+      seq(
+        opt($.attribute_modifier),
+        'trait',
+        field('name', $._semgrep_extended_identifier), // Overridden
+        opt($.type_parameters),
+        opt($.implements_clause),
+        opt($.where_clause),
+        field('body', $.member_declarations)
+      ),
+
+    interface_declaration: ($) =>
+      seq(
+        opt($.attribute_modifier),
+        'interface',
+        field('name', $._semgrep_extended_identifier), // Overridden
+        opt($.type_parameters),
+        opt($.extends_clause),
+        opt($.where_clause),
+        field('body', $.member_declarations)
+      ),
+
+    class_declaration: ($) =>
+      seq(
+        opt($.attribute_modifier),
+        opt($._class_modifier),
+        opt($._class_modifier),
+        opt($.xhp_modifier),
+        'class',
+        field(
+          'name',
+          choice($._semgrep_extended_identifier, $._xhp_identifier) // Overridden
+        ),
+        opt($.type_parameters),
+        opt($.extends_clause),
+        opt($.implements_clause),
+        opt($.where_clause),
+        field('body', $.member_declarations)
+      ),
+
+    _class_const_declarator: ($) =>
+      seq(
+        field(
+          'name',
+          choice(
+            $._semgrep_extended_identifier, // Overridden
+            alias($._keyword, $.identifier)
+          )
+        ),
+        field(
+          'value',
+          // The only reason we need a separate const declarator for classes is that
+          // the assignment expression is optional.
+          seq.opt('=', $._expression)
+        )
+      ),
+
+    type_const_declaration: ($) =>
+      seq(
+        opt($.attribute_modifier),
+        rep($._member_modifier),
+        'const',
+        'type',
+        field('name', $._semgrep_extended_identifier), // Overridden
+        opt($.type_parameters),
+        field('as', seq.opt('as', $._type)),
+        field('type', seq.opt('=', $._type)),
+        ';'
+      ),
+
+    const_declarator: ($) =>
+      seq(
+        field(
+          'name',
+          choice(
+            $._semgrep_extended_identifier, // Overridden
+            alias($._keyword, $.identifier)
+          )
+        ),
+        field('value', seq('=', $._expression))
+      ),
+
+    enum_declaration: ($) =>
+      seq(
+        opt($.attribute_modifier),
+        'enum',
+        field('name', $._semgrep_extended_identifier), // Overridden
+        ':',
+        field('type', $._type),
+        field('as', seq.opt('as', $._type)),
+        '{',
+        rep($.enumerator),
+        '}'
+      ),
+
+    enumerator: ($) =>
+      seq($._semgrep_extended_identifier, '=', $._expression, ';'), // Overridden
   },
 });

--- a/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
@@ -1,0 +1,470 @@
+==========================
+Ellipses as args
+==========================
+
+insecure_function(...);
+func(1, ...);
+func(..., 1);
+requests.get(..., $arg, ...);
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (ellipsis)))))
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer))
+        (argument
+          (ellipsis)))))
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (ellipsis))
+        (argument
+          (integer)))))
+  (expression_statement
+    (binary_expression
+      left: (qualified_identifier
+        (identifier))
+      right: (call_expression
+        function: (qualified_identifier
+          (identifier))
+        (arguments
+          (argument
+            (ellipsis))
+          (argument
+            (variable))
+          (argument
+            (ellipsis)))))))
+
+==========================
+Ellipses as params
+==========================
+
+function is_int(...);
+
+function is_int(..., $var);
+
+function is_int($var, ...);
+
+function is_int($var, ...);
+
+function is_int(..., int ...$arg1);
+
+(...) ==> $x + 1;
+
+<<Attribute, Attribute(...)>>
+class C {
+  <<Attribute(1, ..., 1)>>
+  function method() {}
+}
+
+$f4 = function(..., $p1): int use ($p2, $p3) {};
+$f4 = function(...): int use ($p2, $p3) {};
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (variadic_modifier)))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        (ellipsis))
+      (parameter
+        name: (variable))))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        name: (variable))
+      (parameter
+        (ellipsis))))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        name: (variable))
+      (parameter
+        (ellipsis))))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        (ellipsis))
+      (parameter
+        type: (type_specifier)
+        (variadic_modifier)
+        name: (variable))))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (variadic_modifier))
+      body: (binary_expression
+        left: (variable)
+        right: (integer))))
+  (class_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (ellipsis))))
+    name: (identifier)
+    body: (member_declarations
+      (method_declaration
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer))
+            (argument
+              (ellipsis))
+            (argument
+              (integer))))
+        name: (identifier)
+        (parameters)
+        body: (compound_statement))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (anonymous_function_expression
+        (parameters
+          (parameter
+            (ellipsis))
+          (parameter
+            name: (variable)))
+        return_type: (type_specifier)
+        (use_clause
+          (variable)
+          (variable))
+        body: (compound_statement))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (anonymous_function_expression
+        (parameters
+          (variadic_modifier))
+        return_type: (type_specifier)
+        (use_clause
+          (variable)
+          (variable))
+        body: (compound_statement)))))
+
+==========================
+Ellipses in method chaining
+==========================
+
+$var->make_test()->{...}->test_made();
+// TODO: This should work in XHP attributes and interpolated strings
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (selection_expression
+          (call_expression
+            function: (selection_expression
+              (variable)
+              (qualified_identifier
+                (identifier)))
+            (arguments))
+          (braced_expression
+            (ellipsis)))
+        (qualified_identifier
+          (identifier)))
+      (arguments)))
+  (comment))
+
+==========================
+Ellipses in class def
+==========================
+class Test {
+    ...
+}
+
+class Test {
+    const int hello = 4;
+    ...
+    function tester() {
+    }
+}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    body: (member_declarations
+      (ellipsis)))
+  (class_declaration
+    name: (identifier)
+    body: (member_declarations
+      (const_declaration
+        type: (type_specifier)
+        (const_declarator
+          name: (identifier)
+          value: (integer)))
+      (ellipsis)
+      (method_declaration
+        name: (identifier)
+        (parameters)
+        body: (compound_statement)))))
+
+==========================
+Ellipses in func def
+==========================
+
+function test() {
+    ...
+}
+
+function test() {
+    ...;
+
+}
+function test() {
+    $var = "hello";
+    ...
+    $hello = "hi";
+}
+function test() {
+    $var = "hello";
+    ...;
+    $hello = "hi";
+}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    body: (compound_statement
+      (empty_statement
+        (ellipsis))))
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    body: (compound_statement
+      (expression_statement
+        (ellipsis))))
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    body: (compound_statement
+      (expression_statement
+        (binary_expression
+          left: (variable)
+          right: (string)))
+      (empty_statement
+        (ellipsis))
+      (expression_statement
+        (binary_expression
+          left: (variable)
+          right: (string)))))
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    body: (compound_statement
+      (expression_statement
+        (binary_expression
+          left: (variable)
+          right: (string)))
+      (expression_statement
+        (ellipsis))
+      (expression_statement
+        (binary_expression
+          left: (variable)
+          right: (string))))))
+
+==========================
+Ellipses in binary ops and containers 
+==========================
+
+$X = 1 + 2 + ...;
+
+$v = vec[...];
+$v = vec[..., 1];
+$v = vec[1, ..., 2];
+
+$items = Vector {...};
+$items = Vector {'a', ...};
+$items = Vector {'a', ..., 'b'};
+
+$items = darray['a' => 1, ...];
+$items = darray[..., 'a' => 1];
+
+$v = vec[..., "test", 1 + 2 + ...];
+$v = vec[1 + 2 + ..., ...];
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (binary_expression
+        left: (binary_expression
+          left: (integer)
+          right: (integer))
+        right: (ellipsis))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)
+        (ellipsis))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)
+        (ellipsis)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)
+        (integer)
+        (ellipsis)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (collection
+        (qualified_identifier
+          (identifier))
+        (ellipsis))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (collection
+        (qualified_identifier
+          (identifier))
+        (string)
+        (ellipsis))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (collection
+        (qualified_identifier
+          (identifier))
+        (string)
+        (ellipsis)
+        (string))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)
+        (element_initializer
+          (string)
+          (integer))
+        (ellipsis))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)
+        (ellipsis)
+        (element_initializer
+          (string)
+          (integer)))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)
+        (ellipsis)
+        (string)
+        (binary_expression
+          left: (binary_expression
+            left: (integer)
+            right: (integer))
+          right: (ellipsis)))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)
+        (binary_expression
+          left: (binary_expression
+            left: (integer)
+            right: (integer))
+          right: (ellipsis))
+        (ellipsis)))))
+
+==========================
+Ellipses in conditionals
+==========================
+
+if (...) {
+  ...
+}
+if (...) {
+  ...
+} else {
+  ...
+}
+
+
+if (...)
+  ...
+if (...)
+  ...;
+else
+  ...
+
+---
+
+(script
+  (if_statement
+    condition: (parenthesized_expression
+      (ellipsis))
+    body: (compound_statement
+      (empty_statement
+        (ellipsis))))
+  (if_statement
+    condition: (parenthesized_expression
+      (ellipsis))
+    body: (compound_statement
+      (empty_statement
+        (ellipsis)))
+    else: (compound_statement
+      (empty_statement
+        (ellipsis))))
+  (if_statement
+    condition: (parenthesized_expression
+      (ellipsis))
+    body: (empty_statement
+      (ellipsis)))
+  (if_statement
+    condition: (parenthesized_expression
+      (ellipsis))
+    body: (expression_statement
+      (ellipsis))
+    else: (empty_statement
+      (ellipsis))))

--- a/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
@@ -468,3 +468,409 @@ else
       (ellipsis))
     else: (empty_statement
       (ellipsis))))
+
+==========================
+Metavariables as declaration identifiers
+==========================
+
+function $TEST() {
+  ...
+}
+
+class $TE_ST {
+}
+
+class $F<Ta as A, Tb super B<A, C>> extends B implements A\B<A, C>, C\D {
+  function $M<Ta as A, Tb super B>(): Tc {}
+}
+
+interface $X {
+}
+
+interface $INTER<Ta as A, Tb super B<A, C>> extends B, A\B<A, C>, C\D {
+  function $METHOD<Ta as A, Tb super B>(): Tc {}
+}
+
+
+trait $_X {
+}
+
+trait $F<Ta as A, Tb super B<A, C>> implements A\B<A, C>, C\D {
+}
+
+---
+
+(script
+  (function_declaration
+    name: (semgrep_identifier)
+    (parameters)
+    body: (compound_statement
+      (empty_statement
+        (ellipsis))))
+  (class_declaration
+    name: (semgrep_identifier)
+    body: (member_declarations))
+  (class_declaration
+    name: (semgrep_identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))
+    (extends_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier))))
+    (implements_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier)))
+          (type_specifier
+            (qualified_identifier
+              (identifier)))))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (member_declarations
+      (method_declaration
+        name: (semgrep_identifier)
+        (type_parameters
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier))))
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        (parameters)
+        return_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        body: (compound_statement))))
+  (interface_declaration
+    name: (semgrep_identifier)
+    body: (member_declarations))
+  (interface_declaration
+    name: (semgrep_identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))
+    (extends_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier)))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier)))
+          (type_specifier
+            (qualified_identifier
+              (identifier)))))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (member_declarations
+      (method_declaration
+        name: (semgrep_identifier)
+        (type_parameters
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier))))
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        (parameters)
+        return_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        body: (compound_statement))))
+  (trait_declaration
+    name: (semgrep_identifier)
+    body: (member_declarations))
+  (trait_declaration
+    name: (semgrep_identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))
+    (implements_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier)))
+          (type_specifier
+            (qualified_identifier
+              (identifier)))))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (member_declarations)))
+
+==========================
+Metavariables as attributes
+==========================
+<<$ATTR($C,), Attribute>>
+function func() {
+}
+
+---
+
+(script
+  (function_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (semgrep_identifier))
+      (arguments
+        (argument
+          (variable)))
+      (qualified_identifier
+        (identifier)))
+    name: (identifier)
+    (parameters)
+    body: (compound_statement)))
+
+==========================
+Metavariables as attributes
+==========================
+
+newtype $I = int;
+
+newtype $I as $INT = $BLAH;
+
+---
+
+(script
+  (alias_declaration
+    (semgrep_identifier)
+    (type_specifier))
+  (alias_declaration
+    (semgrep_identifier)
+    as: (type_specifier
+      (qualified_identifier
+        (semgrep_identifier)))
+    (type_specifier
+      (qualified_identifier
+        (semgrep_identifier)))))
+
+==========================
+Metavariables with class declarations
+==========================
+
+class C {
+  abstract const $TYPE $NAME;
+  const $TYPE $NAME = A\B::C0;
+  const $VAR = A\B::C0;
+
+  const int C1 = $TEST;
+  const int C2 = 1, $TEST = $TEST;
+
+
+  const type $VAR;
+  const type $VAR = $TYPE;
+  <<A3(1), A2(2,3,)>>
+  const type T3 as $VAR;
+  const type T4<<<Attr>> T3> as $VAR = $VAR;
+  abstract const type $VAR as ?$VAR = ?$VAR;
+}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    body: (member_declarations
+      (const_declaration
+        (abstract_modifier)
+        type: (type_specifier
+          (qualified_identifier
+            (semgrep_identifier)))
+        (const_declarator
+          name: (semgrep_identifier)))
+      (const_declaration
+        type: (type_specifier
+          (qualified_identifier
+            (semgrep_identifier)))
+        (const_declarator
+          name: (semgrep_identifier)
+          value: (scoped_identifier
+            (qualified_identifier
+              (identifier)
+              (identifier))
+            (identifier))))
+      (const_declaration
+        (const_declarator
+          name: (semgrep_identifier)
+          value: (scoped_identifier
+            (qualified_identifier
+              (identifier)
+              (identifier))
+            (identifier))))
+      (const_declaration
+        type: (type_specifier)
+        (const_declarator
+          name: (identifier)
+          value: (variable)))
+      (const_declaration
+        type: (type_specifier)
+        (const_declarator
+          name: (identifier)
+          value: (integer))
+        (const_declarator
+          name: (semgrep_identifier)
+          value: (variable)))
+      (type_const_declaration
+        name: (semgrep_identifier))
+      (type_const_declaration
+        name: (semgrep_identifier)
+        type: (type_specifier
+          (qualified_identifier
+            (semgrep_identifier))))
+      (type_const_declaration
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer)))
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer))
+            (argument
+              (integer))))
+        name: (identifier)
+        as: (type_specifier
+          (qualified_identifier
+            (semgrep_identifier))))
+      (type_const_declaration
+        name: (identifier)
+        (type_parameters
+          (type_parameter
+            (attribute_modifier
+              (qualified_identifier
+                (identifier)))
+            name: (identifier)))
+        as: (type_specifier
+          (qualified_identifier
+            (semgrep_identifier)))
+        type: (type_specifier
+          (qualified_identifier
+            (semgrep_identifier))))
+      (type_const_declaration
+        (abstract_modifier)
+        name: (semgrep_identifier)
+        as: (type_specifier
+          (nullable_modifier)
+          (qualified_identifier
+            (semgrep_identifier)))
+        type: (type_specifier
+          (nullable_modifier)
+          (qualified_identifier
+            (semgrep_identifier)))))))
+
+==========================
+Metavariables with enums
+==========================
+
+<<$BEENUM>>
+enum $E : $TYPE {
+  F1 = 1;
+  F2 = $VAR;
+  F3 = C::CONST;
+  $TESTER = $BLAH.'b';
+}
+
+---
+
+(script
+  (enum_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (semgrep_identifier)))
+    name: (semgrep_identifier)
+    type: (type_specifier
+      (qualified_identifier
+        (semgrep_identifier)))
+    (enumerator
+      (identifier)
+      (integer))
+    (enumerator
+      (identifier)
+      (variable))
+    (enumerator
+      (identifier)
+      (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier)))
+    (enumerator
+      (semgrep_identifier)
+      (binary_expression
+        left: (variable)
+        right: (string)))))


### PR DESCRIPTION
- Updates tree-sitter-hack to the latest version
- Adds ellipsis support in statements, expressions, member declarations, and parameter (testing included as well)

Build should match https://github.com/frankeld/semgrep-hack/tree/release-6f0bf4c