### PR TITLE
Switch to more idiomatic syntax in grammar extension template

### DIFF
--- a/lang/semgrep-grammars/sg-add-simple-lang
+++ b/lang/semgrep-grammars/sg-add-simple-lang
@@ -135,12 +135,10 @@ module.exports = grammar(base_grammar, {
   /*
     semgrep_ellipsis: \$ => '...',
 
-    _expression: (\$, previous) => {
-      return choice(
-        \$.semgrep_ellipsis,
-        ...previous.members
-      );
-    }
+    _expression: (\$, previous) => choice(
+      \$.semgrep_ellipsis,
+      ...previous.members
+    ),
   */
   }
 });


### PR DESCRIPTION
This should reduce the confusion of contributors. Also, the [documentation now explains](https://semgrep.dev/docs/contributing/adding-a-language/#extending-the-original-grammar-with-semgrep-syntax) the various syntaxes for javascript lambdas.
