### PR TITLE
Improve hack matching

### DIFF
--- a/lang/hack/projects.txt
+++ b/lang/hack/projects.txt
@@ -2,7 +2,7 @@
 # one per line.
 #
 https://github.com/facebookarchive/hack-example-site.git
-https://github.com/titon/framework.git
+# https://github.com/titon/framework.git
 https://github.com/facebookarchive/oss-performance.git
 https://github.com/igorw/reasoned-php.git
 https://github.com/hacktx/nucleus.git
@@ -17,7 +17,7 @@ https://github.com/ivivian/EchartSample.git
 https://github.com/JarJarBernie/jimmybox5.git
 https://github.com/XinLiangCoder/web_barrage.git
 https://github.com/wangzhenjjcn/WZ_WEB_ENGINE.git
-https://github.com/nuxed/framework.git
+# https://github.com/nuxed/framework.git
 https://github.com/hhvm/type-assert.git
 https://github.com/pauloamgomes/BackupAndRestore.git
 https://github.com/iamcal/grant-pattishall-award.com.git

--- a/lang/semgrep-grammars/src/semgrep-hack/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-hack/grammar.js
@@ -97,6 +97,7 @@ module.exports = grammar(base_grammar, {
     */
 
     semgrep_identifier: ($) => /\$[A-Z_][A-Z_0-9]*/,
+    _semgrep_variadic_identifier: ($) => /\$\.\.\.[A-Z_][A-Z_0-9]*/,
     _semgrep_extended_identifier: ($) =>
       choice($.semgrep_identifier, $.identifier),
 
@@ -243,5 +244,11 @@ module.exports = grammar(base_grammar, {
 
     enumerator: ($) =>
       seq($._semgrep_extended_identifier, '=', $._expression, ';'), // Overridden
+
+    /*
+      Support for semgrep variadic metavariables ('$...ARGS')
+    */
+
+    argument: ($, previous) => choice(previous, $._semgrep_variadic_identifier),
   },
 });

--- a/lang/semgrep-grammars/src/semgrep-hack/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-hack/grammar.js
@@ -41,6 +41,12 @@ module.exports = grammar(base_grammar, {
   conflicts: ($, previous) => previous.concat([]),
 
   rules: {
+    // Entry point
+    script: ($, previous) => choice(previous, $.semgrep_expression),
+
+    // Alternate "entry point". Allows parsing a standalone expression.
+    semgrep_expression: ($) => seq('__SEMGREP_EXPRESSION', $._expression),
+
     /*
       Support for semgrep ellipsis ('...')
     */
@@ -51,22 +57,19 @@ module.exports = grammar(base_grammar, {
 
     // By using an empty statement, we leverage a statement type that is strictly only used within
     // $._statement and nowhere else.
-    empty_statement: ($, previous) => {
-      return choice(
+    empty_statement: ($, previous) =>
+      choice(
         previous,
         // For conflict with `ellipsis;`
         // we want it to be read as an expression with a semicolon
         // instead of a statement
         prec(-1, $.ellipsis) // statement ellipsis
-      );
-    },
+      ),
 
-    _expression: ($, previous) => {
-      return choice(previous, $.ellipsis, $.deep_ellipsis);
-    },
+    _expression: ($, previous) => choice(previous, $.ellipsis, $.deep_ellipsis),
 
-    member_declarations: ($) => {
-      return seq(
+    member_declarations: ($) =>
+      seq(
         '{',
         choice.rep(
           // Copied from existing grammar
@@ -85,12 +88,9 @@ module.exports = grammar(base_grammar, {
           $.ellipsis
         ),
         '}'
-      );
-    },
+      ),
 
-    parameter: ($, previous) => {
-      return choice(previous, $.ellipsis);
-    },
+    parameter: ($, previous) => choice(previous, $.ellipsis),
 
     /*
       Support for semgrep metavariables ('$FOO')
@@ -108,9 +108,8 @@ module.exports = grammar(base_grammar, {
     // metavariable overrides (like in XHP). Or get global $.identifier
     // extension working.
 
-    qualified_identifier: ($, previous) => {
-      return choice(previous, $.semgrep_identifier);
-    },
+    qualified_identifier: ($, previous) =>
+      choice(previous, $.semgrep_identifier),
 
     // Alternative reach-in edit strategy:
     /*

--- a/lang/semgrep-grammars/src/semgrep-hack/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-hack/grammar.js
@@ -41,12 +41,6 @@ module.exports = grammar(base_grammar, {
   conflicts: ($, previous) => previous.concat([]),
 
   rules: {
-    // Entry point
-    script: ($, previous) => choice(previous, $.semgrep_expression),
-
-    // Alternate "entry point". Allows parsing a standalone expression.
-    semgrep_expression: ($) => seq('__SEMGREP_EXPRESSION', $._expression),
-
     /*
       Support for semgrep ellipsis ('...')
     */

--- a/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
@@ -893,31 +893,3 @@ enum $E : $TYPE {
       (binary_expression
         left: (variable)
         right: (string)))))
-
-==========================
-Standalone expression (v1)
-==========================
-
-__SEMGREP_EXPRESSION$X == $X
-
----
-
-(script
-  (semgrep_expression
-    (binary_expression
-      left: (variable)
-      right: (variable))))
-
-==========================
-Standalone expression (v2)
-==========================
-
-__SEMGREP_EXPRESSION $X == $X
-
----
-
-(script
-  (semgrep_expression
-    (binary_expression
-      left: (variable)
-      right: (variable))))

--- a/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
@@ -470,6 +470,25 @@ else
       (ellipsis))))
 
 ==========================
+Ellipses + metavariables as args
+==========================
+
+foo($...ARGS, 3, $...ARGS);
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (arguments
+        (argument)
+        (argument
+          (integer))
+        (argument)))))
+
+==========================
 Metavariables as declaration identifiers
 ==========================
 

--- a/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-hack/test/corpus/semgrep.txt
@@ -874,3 +874,31 @@ enum $E : $TYPE {
       (binary_expression
         left: (variable)
         right: (string)))))
+
+==========================
+Standalone expression (v1)
+==========================
+
+__SEMGREP_EXPRESSION$X == $X
+
+---
+
+(script
+  (semgrep_expression
+    (binary_expression
+      left: (variable)
+      right: (variable))))
+
+==========================
+Standalone expression (v2)
+==========================
+
+__SEMGREP_EXPRESSION $X == $X
+
+---
+
+(script
+  (semgrep_expression
+    (binary_expression
+      left: (variable)
+      right: (variable))))


### PR DESCRIPTION
- Adds support for `$...ARGS`
- Standardizes syntax
- Updates TSH
- Uses https://github.com/nazg-hack/framework.git as the framework-named repo of choice (the other one is written in 6 year old syntax)