### PR TITLE
New tree-sitter-hcl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = https://github.com/slackhq/tree-sitter-hack.git
 [submodule "lang/semgrep-grammars/src/tree-sitter-hcl"]
 	path = lang/semgrep-grammars/src/tree-sitter-hcl
-	url = https://github.com/mitchellh/tree-sitter-hcl.git
+	url = https://github.com/MichaHoffmann/tree-sitter-hcl.git
 [submodule "core"]
 	path = core
 	url = git@github.com:returntocorp/ocaml-tree-sitter-core.git


### PR DESCRIPTION
We are now using a different tree-sitter-hcl repository. This one
was not created by the original creator of HCL, but it seems more
active and is also more complete (it parses interpolated strings,
which is quite important for semgrep users).

Test plan:
cd lang; ./test-lang hcl
...
hcl/: OK