### PR TITLE
Use back the original fcwd/tree-sitter-kotlin repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/tree-sitter/tree-sitter-ruby.git
 [submodule "lang/semgrep-grammars/src/tree-sitter-kotlin"]
 	path = lang/semgrep-grammars/src/tree-sitter-kotlin
-	url = https://github.com/returntocorp/tree-sitter-kotlin.git
+	url = https://github.com/fwcd/tree-sitter-kotlin.git
 [submodule "lang/semgrep-grammars/src/tree-sitter-c-sharp"]
 	path = lang/semgrep-grammars/src/tree-sitter-c-sharp
 	url = https://github.com/tree-sitter/tree-sitter-c-sharp.git


### PR DESCRIPTION
I get 71% parsing stats with it instead of 69% with
our fork (which contains a few improvements).
I think we should restart from scratch and make proper
PR to this original repo.

test plan:
```
$ cd lang ./test-lang kotlin
...
OK
$ cd kotlin
$ ~/github/ocaml-tree-sitter-semgrep/scripts/lang-stat kotlin projects.txt extensions.txt
...
71%
```


### Security

- [ ] Change has security implications (if so, ping the security team)