### PR TITLE
Fix tree-sitter-rust submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/Azganoth/tree-sitter-lua
 [submodule "lang/semgrep-grammars/src/tree-sitter-rust"]
 	path = lang/semgrep-grammars/src/tree-sitter-rust
-	url = git://github.com/tree-sitter/tree-sitter-rust.git
+	url = https://github.com/tree-sitter/tree-sitter-rust
 [submodule "lang/semgrep-grammars/src/tree-sitter-r"]
 	path = lang/semgrep-grammars/src/tree-sitter-r
 	url = https://github.com/r-lib/tree-sitter-r


### PR DESCRIPTION
The scheme `git://` can't be used without authentication (or something like this). I was getting the following error and the [stats jobs was failing](https://app.circleci.com/pipelines/github/returntocorp/ocaml-tree-sitter-semgrep/1201/workflows/f6b0aaac-95e6-49e4-b5c3-5c593795251f/jobs/1242).

```
$ git submodule update --init --recursive
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Unable to fetch in submodule path 'lang/semgrep-grammars/src/tree-sitter-rust'; trying to directly fetch d045b04b66d51c0ba8671e7ce1ee23a9f286b7d7:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: Fetched in submodule path 'lang/semgrep-grammars/src/tree-sitter-rust', but it did not contain d045b04b66d51c0ba8671e7ce1ee23a9f286b7d7. Direct fetching of that commit failed.
```

### Security

- [x] Change has no security implications (otherwise, ping the security team)
