### PR TITLE
More semgrep extensions for dockerfile

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
@@ -62,11 +62,23 @@ module.exports = grammar(base_grammar, {
       )
     ),
 
+    // override
     label_pair: ($, previous) => choice(
       $.semgrep_ellipsis,
-      previous
+      seq(
+        field(
+          "key",
+          choice(
+            $.semgrep_metavariable,
+            alias(/[-a-zA-Z0-9\._]+/, $.unquoted_string)
+          )
+        ),
+        token.immediate("="),
+        field("value", choice($.double_quoted_string, $.unquoted_string))
+      )
     ),
 
+    // TODO: find a way to support metavariables as env keys.
     env_pair: ($, previous) => choice(
       $.semgrep_ellipsis,
       previous
@@ -108,7 +120,7 @@ module.exports = grammar(base_grammar, {
       FROM extras:$CODE_VERSION       # metavariable (pattern only)
       FROM extras:${CODE_VERSION}     # parameter from ARG
 
-      mv: (tricky like ENV)
+      mv: done
       LABEL $NAME=$VAL
 
       e: done

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
@@ -35,12 +35,25 @@ module.exports = grammar(base_grammar, {
       $.semgrep_metavariable
     ),
 
-    // TODO: support metavariables and ellipses in a bunch of places
+    /*
+      Metavariable syntax vs. ARG expansions:
+
+      - in a semgrep pattern, $FOO is always a metavariable.
+      - in a semgrep pattern, ${FOO} is always an arg expansion.
+      - in a semgrep pattern, $FOO in a position where a metavariable
+        is not allowed results in an error.
+
+     TODO: support metavariables and ellipses in a bunch of places
+    */
     semgrep_metavariable: $ => /\$[A-Z_][A-Z_0-9]*/,
     semgrep_ellipsis: $ => '...',
 
     /*
       TODO: more syntax ellipsis (e) or metavariables (mv):
+
+      mv:
+      FROM extras:$CODE_VERSION       # metavariable (pattern only)
+      FROM extras:${CODE_VERSION}     # parameter from ARG
 
       e, mv:
       LABEL multi.label1="value1" multi.label2="value2" other="value3"

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -75,6 +75,8 @@ ADD --chown=$USER_GROUP src dst
 
 ---
 
+; '$PLATFORM' is already allowed as parameter value by the dockerfile syntax.
+;
 (source_file
   (from_instruction
     (param)
@@ -94,6 +96,10 @@ FROM ${NAME}:${TAG}@${DIGEST}
 
 ---
 
+; $NAME and ${NAME} are dockerfile variable expansions. We will use
+; the former syntax for metavariables in Semgrep patterns, like we do
+; with Bash.
+;
 (source_file
   (from_instruction
     (image_spec
@@ -178,6 +184,9 @@ VOLUME ...
 
 ---
 
+; '...' is a valid path. In Semgrep patterns, it will be interpreted
+; as an ellipsis.
+;
 (source_file
   (add_instruction
     (path)
@@ -379,6 +388,10 @@ MAINTAINER $NAME
 
 ---
 
+; The maintainer string can be anything, including $NAME. It will need
+; to be interpreted as a metavariable in the context of Semgrep
+; patterns.
+;
 (source_file
   (maintainer_instruction)
   (maintainer_instruction))

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -65,3 +65,22 @@ RUN ["a", $X, "b"]
       (double_quoted_string)
       (semgrep_metavariable)
       (double_quoted_string))))
+
+=============================================
+Param metavariable
+=============================================
+
+FROM --platform=$PLATFORM debian
+ADD --chown=$USER_GROUP src dst
+
+---
+
+(source_file
+  (from_instruction
+    (param)
+    (image_spec
+      (image_name)))
+  (add_instruction
+    (param)
+    (path)
+    (path)))

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -84,3 +84,218 @@ ADD --chown=$USER_GROUP src dst
     (param)
     (path)
     (path)))
+
+=============================================
+Image metavariable
+=============================================
+
+FROM $NAME:$TAG@$DIGEST
+FROM ${NAME}:${TAG}@${DIGEST}
+
+---
+
+(source_file
+  (from_instruction
+    (image_spec
+      (image_name
+        (expansion
+          (variable)))
+      (image_tag
+        (expansion
+          (variable)))
+      (image_digest
+        (expansion
+          (variable)))))
+  (from_instruction
+    (image_spec
+      (image_name
+        (expansion
+          (variable)))
+      (image_tag
+        (expansion
+          (variable)))
+      (image_digest
+        (expansion
+          (variable))))))
+
+=============================================
+Image alias metavariable
+=============================================
+
+FROM debian AS $ALIAS
+
+---
+
+(source_file
+  (from_instruction
+    (image_spec
+      (image_name))
+    (image_alias
+      (expansion
+        (variable)))))
+
+=============================================
+File metavariables
+=============================================
+
+ADD $A $B $DST
+COPY $A $B $DST
+VOLUME $A
+
+---
+
+(source_file
+  (add_instruction
+    (path
+      (expansion
+        (variable)))
+    (path
+      (expansion
+        (variable))
+      (expansion
+        (variable))))
+  (copy_instruction
+    (path
+      (expansion
+        (variable)))
+    (path
+      (expansion
+        (variable))
+      (expansion
+        (variable))))
+  (volume_instruction
+    (path
+      (expansion
+        (variable)))))
+
+=============================================
+File list ellipsis
+=============================================
+
+ADD ... dst
+COPY ... dst
+VOLUME ...
+
+---
+
+(source_file
+  (add_instruction
+    (path)
+    (path))
+  (copy_instruction
+    (path)
+    (path))
+  (volume_instruction
+    (path)))
+
+=============================================
+Workdir metavariable
+=============================================
+
+WORKDIR $DIR
+
+---
+
+(source_file
+  (workdir_instruction
+    (path
+      (expansion
+        (variable)))))
+
+=============================================
+Arg metavariables
+=============================================
+
+ARG $KEY
+ARG $KEY=$DEFAULT
+
+---
+
+(source_file
+  (arg_instruction
+    (unquoted_string))
+  (arg_instruction
+    (unquoted_string)
+    (unquoted_string
+      (expansion
+        (variable)))))
+
+=============================================
+User and group metavariables
+=============================================
+
+USER $USER
+USER $USER:$GROUP
+
+---
+
+(source_file
+  (user_instruction
+    (unquoted_string
+      (expansion
+        (variable))))
+  (user_instruction
+    (unquoted_string
+      (expansion
+        (variable)))
+    (unquoted_string
+      (expansion
+        (variable)))))
+
+=============================================
+Env ellipsis
+=============================================
+
+ENV ...
+ENV AA=42 ...
+ENV AA=42 ... BB=17
+
+---
+
+(source_file
+  (env_instruction
+    (env_pair
+      (semgrep_ellipsis)))
+  (env_instruction
+    (env_pair
+      (unquoted_string)
+      (unquoted_string))
+    (env_pair
+      (semgrep_ellipsis)))
+  (env_instruction
+    (env_pair
+      (unquoted_string)
+      (unquoted_string))
+    (env_pair
+      (semgrep_ellipsis))
+    (env_pair
+      (unquoted_string)
+      (unquoted_string))))
+
+=============================================
+Env value metavariable
+=============================================
+
+ENV KEY=$VALUE KEY2=$VALUE2
+ENV KEY3 $VALUE3
+
+---
+
+(source_file
+  (env_instruction
+    (env_pair
+      (unquoted_string)
+      (unquoted_string
+        (expansion
+          (variable))))
+    (env_pair
+      (unquoted_string)
+      (unquoted_string
+        (expansion
+          (variable)))))
+  (env_instruction
+    (env_pair
+      (unquoted_string)
+      (unquoted_string
+        (expansion
+          (variable))))))

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -189,7 +189,7 @@ VOLUME ...
     (path)))
 
 =============================================
-Workdir metavariable
+WORKDIR metavariable
 =============================================
 
 WORKDIR $DIR
@@ -203,7 +203,7 @@ WORKDIR $DIR
         (variable)))))
 
 =============================================
-Arg metavariables
+ARG metavariables
 =============================================
 
 ARG $KEY
@@ -243,7 +243,37 @@ USER $USER:$GROUP
         (variable)))))
 
 =============================================
-Env ellipsis
+LABEL ellipsis
+=============================================
+
+LABEL ...
+LABEL version="1.0" ...
+LABEL com.example.label-with-value=foo ... version="1.0"
+
+---
+
+(source_file
+  (label_instruction
+    (label_pair
+      (semgrep_ellipsis)))
+  (label_instruction
+    (label_pair
+      (unquoted_string)
+      (double_quoted_string))
+    (label_pair
+      (semgrep_ellipsis)))
+  (label_instruction
+    (label_pair
+      (unquoted_string)
+      (unquoted_string))
+    (label_pair
+      (semgrep_ellipsis))
+    (label_pair
+      (unquoted_string)
+      (double_quoted_string))))
+
+=============================================
+ENV ellipsis
 =============================================
 
 ENV ...
@@ -273,7 +303,7 @@ ENV AA=42 ... BB=17
       (unquoted_string))))
 
 =============================================
-Env value metavariable
+ENV value metavariable
 =============================================
 
 ENV KEY=$VALUE KEY2=$VALUE2
@@ -299,3 +329,76 @@ ENV KEY3 $VALUE3
       (unquoted_string
         (expansion
           (variable))))))
+
+=============================================
+MAINTAINER metavariable
+=============================================
+
+MAINTAINER Spongebob Squarepants <sponge@bb.net>
+MAINTAINER $NAME
+
+---
+
+(source_file
+  (maintainer_instruction)
+  (maintainer_instruction))
+
+=============================================
+EXPOSE metavariable and ellipsis
+=============================================
+
+EXPOSE 80/udp 80/tcp
+EXPOSE ...
+EXPOSE ... $PORT_PROTO ...
+
+---
+
+(source_file
+  (expose_instruction
+    (expose_port)
+    (expose_port))
+  (expose_instruction
+    (expose_port
+      (semgrep_ellipsis)))
+  (expose_instruction
+    (expose_port
+      (semgrep_ellipsis))
+    (expansion
+      (variable))
+    (expose_port
+      (semgrep_ellipsis))))
+
+=============================================
+STOPSIGNAL metavariable
+=============================================
+
+STOPSIGNAL SIGFOO
+STOPSIGNAL $SIGNAL
+
+---
+
+(source_file
+  (stopsignal_instruction)
+  (stopsignal_instruction
+    (expansion
+      (variable))))
+
+=============================================
+HEALTHCHECK
+=============================================
+
+HEALTHCHECK NONE
+HEALTHCHECK --timeout=30s CMD echo hello
+HEALTHCHECK $X
+
+---
+
+(source_file
+  (healthcheck_instruction)
+  (healthcheck_instruction
+    (param)
+    (cmd_instruction
+      (shell_command
+        (shell_fragment))))
+  (healthcheck_instruction
+    (semgrep_metavariable)))

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -273,6 +273,46 @@ LABEL com.example.label-with-value=foo ... version="1.0"
       (double_quoted_string))))
 
 =============================================
+LABEL metavariables
+=============================================
+
+LABEL foo=abc
+LABEL $NAME=abc
+LABEL foo=$VALUE
+LABEL $A=$B ... $C=$D
+
+---
+
+(source_file
+  (label_instruction
+    (label_pair
+      (unquoted_string)
+      (unquoted_string)))
+  (label_instruction
+    (label_pair
+      (semgrep_metavariable)
+      (unquoted_string)))
+  (label_instruction
+    (label_pair
+      (unquoted_string)
+      (unquoted_string
+        (expansion
+          (variable)))))
+  (label_instruction
+    (label_pair
+      (semgrep_metavariable)
+      (unquoted_string
+        (expansion
+          (variable))))
+    (label_pair
+      (semgrep_ellipsis))
+    (label_pair
+      (semgrep_metavariable)
+      (unquoted_string
+        (expansion
+          (variable))))))
+
+=============================================
 ENV ellipsis
 =============================================
 


### PR DESCRIPTION
Most metavariables are already covered by `$.expansion`, which is a shell-like variable expansion and string concatenation supported by dockerfile.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
