### PR TITLE
[HTML] support metavar for tags

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-html/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-html/grammar.js
@@ -13,19 +13,35 @@ module.exports = grammar(base_grammar, {
   ]),
 
   /*
-     Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
-     if they're not already part of the base grammar.
+     ellipsis ('...') and metavariables ('$FOO') are actually
+     valid HTML syntax in many places, so we don't need that many
+     grammar extensions
   */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
+    //alt: redefine instead _start_tag_name and _end_tag_name?
+    start_tag: ($, previous) => choice(
+      $.semgrep_start_tag,
+      previous
+    ),
+    end_tag: ($, previous) => choice(
+      $.semgrep_end_tag,
+      previous
+    ),
 
-    _expression: ($, previous) => {
-      return choice(
-        $.semgrep_ellipsis,
-        ...previous.members
-      );
-    }
-  */
+    semgrep_start_tag: $ => seq(
+      '<',
+      $.semgrep_metavariable,
+      repeat($.attribute),
+      '>'
+    ),
+
+    semgrep_end_tag: $ => seq(
+      '</',
+      $.semgrep_metavariable,
+      '>'
+    ),
+
+    semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
+      
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-html/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-html/test/corpus/semgrep.txt
@@ -1,0 +1,64 @@
+===================================
+Metavariable tag
+===================================
+<$X>foo</$X>
+---
+
+(fragment
+  (element
+    (start_tag (semgrep_start_tag (semgrep_metavariable)))
+    (text)
+    (end_tag (semgrep_end_tag (semgrep_metavariable)))))
+
+===================================
+Metavariable attribute
+===================================
+<span $X="foo">Hello</span>
+
+---
+
+(fragment
+  (element
+    (start_tag (tag_name)
+       (attribute (attribute_name) (quoted_attribute_value (attribute_value))))
+    (text)
+    (end_tag (tag_name))))
+
+===================================
+Metavariable attribute value
+===================================
+<span a="$X">Hello</span>
+
+---
+
+(fragment
+  (element
+    (start_tag (tag_name)
+       (attribute (attribute_name) (quoted_attribute_value (attribute_value))))
+    (text)
+    (end_tag (tag_name))))
+
+===================================
+Metavariable body
+===================================
+<span>$BODY</span>
+
+---
+(fragment
+   (element
+      (start_tag (tag_name))
+      (text)
+      (end_tag (tag_name))))
+
+===================================
+Ellipsis in attributes and body
+===================================
+
+<script ... >...</script>
+
+---
+(fragment
+  (script_element
+     (start_tag (tag_name) (attribute (attribute_name)))
+     (raw_text)
+     (end_tag (tag_name))))


### PR DESCRIPTION
This overrides a very old PR:
https://github.com/returntocorp/ocaml-tree-sitter-semgrep/pull/234

test plan:
./test-lang html


### Security

- [ ] Change has no security implications (otherwise, ping the security team)