### PR TITLE
Extend dockerfile grammar to identify toplevel ellipses early e.g. 'RUN ...'

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
@@ -100,6 +100,11 @@ module.exports = grammar(base_grammar, {
         )
       ),
 
+    shell_command: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      previous
+    ),
+
     /*
       Metavariable syntax vs. ARG expansions:
 

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -52,6 +52,19 @@ RUN ["a", ..., "b"]
       (double_quoted_string))))
 
 =============================================
+Shell or argv ellipsis
+=============================================
+
+RUN ...
+
+---
+
+(source_file
+  (run_instruction
+    (shell_command
+      (semgrep_ellipsis))))
+
+=============================================
 Array metavariable
 =============================================
 


### PR DESCRIPTION
Extend dockerfile grammar to identify ellipses placed as the only argument of a CMD/RUN/... instruction.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
