### PR TITLE
Update to latest Go

### DIFF
--- a/lang/test-lang
+++ b/lang/test-lang
@@ -66,7 +66,7 @@ fi
 
 check_for_blanks() {
   cst_ml=ocaml-src/lib/CST.ml
-  if grep -C 2 Blank "$cst_ml"; then
+  if grep -C 2 '\bBlank\b' "$cst_ml"; then
     cat 2>&1 <<EOF
 
 found in $(pwd)/$cst_ml


### PR DESCRIPTION
Also fixed errors from ocaml-tree-sitter about
a Blank node.
See
https://github.com/tree-sitter/tree-sitter-go/commit/e9e693780c647c46c37336af9a4b44d343a526f6

test plan:
./test-lang go


### Security

- [ ] Change has no security implications (otherwise, ping the security team)