### PR TITLE
Upgrade tree-sitter-dockerfile

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -142,10 +142,17 @@ Image alias metavariable
 =============================================
 
 FROM debian AS $ALIAS
+FROM debian as $ALIAS
 
 ---
 
 (source_file
+  (from_instruction
+    (image_spec
+      (image_name))
+    (image_alias
+      (expansion
+        (variable))))
   (from_instruction
     (image_spec
       (image_name))
@@ -170,7 +177,8 @@ VOLUME $A
         (variable)))
     (path
       (expansion
-        (variable))
+        (variable)))
+    (path
       (expansion
         (variable))))
   (copy_instruction
@@ -179,7 +187,8 @@ VOLUME $A
         (variable)))
     (path
       (expansion
-        (variable))
+        (variable)))
+    (path
       (expansion
         (variable))))
   (volume_instruction


### PR DESCRIPTION
This update fixes issues of space-separated elements that were parsed as one (https://github.com/camdencheek/tree-sitter-dockerfile/pull/20). It was affecting the `COPY` instructions, which explains the changes in the test expectations.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
