### PR TITLE
Add syntax for named ellipses in bash patterns

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-bash/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-bash/grammar.js
@@ -40,14 +40,13 @@ module.exports = grammar(base_grammar, {
     // Regular ellipses '...' are already parsed as 'word'.
     semgrep_named_ellipsis: $ => /\$\.\.\.[A-Z_][A-Z_0-9]*/,
 
-    // This should parse the same input as the original. It should not
-    // parse '$$X' as "expand metavariable $X".
-    //
-    // TODO: use token.immediate(...) to only accept variables that stick
-    //       to the '$'.
-    //       This should be fixed in the original grammar as well.
     simple_expansion: $ => choice(
       seq(
+        // This should parse the same input as the original. It should not
+        // parse '$$X' as "expand metavariable $X".
+        // TODO: use token.immediate(...) to only accept variables that stick
+        //       to the '$'.
+        //       This should be fixed in the original grammar as well.
         '$',
         choice(
           $._orig_simple_variable_name,  // no metavariable allowed here

--- a/lang/semgrep-grammars/src/semgrep-bash/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-bash/grammar.js
@@ -27,6 +27,7 @@ module.exports = grammar(base_grammar, {
 
     _primary_expression: ($, previous) => choice(
       $.semgrep_deep_expression,
+      $.semgrep_named_ellipsis,
       previous
     ),
 
@@ -35,6 +36,10 @@ module.exports = grammar(base_grammar, {
       $._literal,  // includes concatenations and unquoted expansions
       '...>'
     ),
+
+    // Named ellipses like '$...HELLO'.
+    // Regular ellipses '...' are already parsed as 'word'.
+    semgrep_named_ellipsis: $ => /\$\.\.\.[A-Z_][A-Z_0-9]*/,
 
     // This should parse the same input as the original. It should not
     // parse '$$X' as "expand metavariable $X".

--- a/lang/semgrep-grammars/src/semgrep-bash/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-bash/grammar.js
@@ -27,7 +27,6 @@ module.exports = grammar(base_grammar, {
 
     _primary_expression: ($, previous) => choice(
       $.semgrep_deep_expression,
-      $.semgrep_named_ellipsis,
       previous
     ),
 
@@ -43,14 +42,21 @@ module.exports = grammar(base_grammar, {
 
     // This should parse the same input as the original. It should not
     // parse '$$X' as "expand metavariable $X".
-    simple_expansion: $ => seq(
-      '$',
-      choice(
-        $._orig_simple_variable_name,  // no metavariable allowed here
-        $._special_variable_name,
-        alias('!', $.special_variable_name),
-        alias('#', $.special_variable_name)
-      )
+    //
+    // TODO: use token.immediate(...) to only accept variables that stick
+    //       to the '$'.
+    //       This should be fixed in the original grammar as well.
+    simple_expansion: $ => choice(
+      seq(
+        '$',
+        choice(
+          $._orig_simple_variable_name,  // no metavariable allowed here
+          $._special_variable_name,
+          alias('!', $.special_variable_name),
+          alias('#', $.special_variable_name)
+        )
+      ),
+      $.semgrep_named_ellipsis
     ),
 
     // Override variable assignments to treat '$X=42' as an assignment rather

--- a/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
@@ -318,6 +318,8 @@ Named ellipses
 
 apt-get install $...ARGS
 $...ARGS and more
+"$...X"
+"foo$...Xbar"
 
 ---
 
@@ -326,9 +328,21 @@ $...ARGS and more
     (command_name
       (word))
     (word)
-    (semgrep_named_ellipsis))
+    (simple_expansion
+      (semgrep_named_ellipsis)))
   (command
     (command_name
-      (semgrep_named_ellipsis))
+      (simple_expansion
+        (semgrep_named_ellipsis)))
     (word)
-    (word)))
+    (word))
+  (command
+    (command_name
+      (string
+        (simple_expansion
+          (semgrep_named_ellipsis)))))
+  (command
+    (command_name
+      (string
+        (simple_expansion
+          (semgrep_named_ellipsis))))))

--- a/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
@@ -311,3 +311,24 @@ a <... 'b'$c ...>
         (raw_string)
         (simple_expansion
           (variable_name))))))
+
+======================================================================
+Named ellipses
+======================================================================
+
+apt-get install $...ARGS
+$...ARGS and more
+
+---
+
+(program
+  (command
+    (command_name
+      (word))
+    (word)
+    (semgrep_named_ellipsis))
+  (command
+    (command_name
+      (semgrep_named_ellipsis))
+    (word)
+    (word)))


### PR DESCRIPTION
Adds support for e.g. `$...HELLO`, which otherwise would be a syntax error.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
