### PR TITLE
Migrate from `semgrep-action` to `semgrep ci`

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,9 +9,10 @@ jobs:
   semgrep:
     name: Scan
     runs-on: ubuntu-latest
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    container:
+      image: returntocorp/semgrep
     steps:
-    - uses: actions/checkout@v2
-    - uses: returntocorp/semgrep-action@v1
-      with:
-        auditOn: push
-        publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+    - uses: actions/checkout@v3
+    - run: semgrep ci


### PR DESCRIPTION
The former is sunsetting and we should move to the native functionality. See also https://github.com/returntocorp/semgrep-action/blob/develop/README.md

### Security

- [x] Change has no security implications (otherwise, ping the security team)
