### PR TITLE
Elixir: support metavar and deep ellisps for semgrep

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
@@ -17,13 +17,31 @@ module.exports = grammar(base_grammar, {
      if they're not already part of the base grammar.
   */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
+    // No need for _SEMGREP_EXPRESSION hack here, because Elixir allows
+    // toplevel expressions.
+      
+    // Metavariables
+    identifier: ($, previous) => {
+      return choice(
+        previous,
+        $._semgrep_metavariable
+      );
+    },
 
+    _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
+
+    // Ellipsis
+    // No need for extensions to _expressions for ellipsis because
+    // Elixir already uses "..." as valid identifiers
+      
     _expression: ($, previous) => choice(
-      $.semgrep_ellipsis,
-      ...previous.members
+      ...previous.members,
+      $.deep_ellipsis,
     ),
-  */
+      
+    // The actual ellipsis rules
+    deep_ellipsis: $ => seq(
+            '<...', $._expression, '...>'
+    ),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
@@ -1,0 +1,44 @@
+=====================================
+Metavariables
+=====================================
+
+def $FOO do
+  $BAR(1, 2)
+end
+
+---
+
+(source
+	(call (identifier)
+	      (arguments (identifier))
+	      (do_block (call (identifier) (arguments (integer) (integer))))))
+
+=====================================
+Ellipsis in calls
+=====================================
+
+def foo do
+  bar(1, ..., 2)
+end
+
+---
+
+(source (call (identifier) (arguments (identifier))
+   (do_block
+	(call (identifier)
+	      (arguments (integer) (identifier) (integer))))))
+
+=====================================
+Deep Ellipsis
+=====================================
+
+def foo do
+  bar(1, <... 3 ...>, 2)
+end
+
+---
+(source
+  (call (identifier)
+    (arguments (identifier))
+    (do_block (call (identifier)
+    	      (arguments (integer) (deep_ellipsis (integer)) (integer))))))


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/3698

test plan:
test corpus included


### Security

- [x] Change has no security implications (otherwise, ping the security team)