### PR TITLE
fix(swift): added semicolon to test

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
@@ -109,10 +109,10 @@ Class Ellipsis Sandwiched
 
 class ClassName {
   ...
-  var x = 2
+  var x = 2;
   ...
 }
 
 --------------------------------------------------------------------------------
 
-(source_file (class_declaration (type_identifier) (class_body (semgrep_ellipsis) (property_declaration (pattern (simple_identifier)) (open_end_range_expression (integer_literal))))))
+(source_file (class_declaration (type_identifier) (class_body (semgrep_ellipsis) (property_declaration (pattern (simple_identifier)) (integer_literal)) (semgrep_ellipsis))))


### PR DESCRIPTION
**What:**
Added a semicolon because I didn't separate the statements with ellipses the way I intended

**Test plan:**
`./test-lang swift`

### Security

- [X] Change has no security implications (otherwise, ping the security team)
