### PR TITLE
Fix remaining Swift test failures

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-swift/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-swift/grammar.js
@@ -48,11 +48,5 @@ module.exports = grammar(base_grammar, {
       previous,
       $.semgrep_ellipsis,
     ),
-
-    // Avoid problem with ocaml-tree-sitter due to $.multiline_comment
-    // being an extra that can occur anywhere (like a comment) which is
-    // removed from the CST.
-    //_class_member_separator: ($) => choice($._semi, $.multiline_comment),
-    _class_member_separator: ($) => $._semi,
   }
 });


### PR DESCRIPTION
This updates ocaml-tree-sitter-core to pull in https://github.com/returntocorp/ocaml-tree-sitter-core/pull/43, https://github.com/returntocorp/ocaml-tree-sitter-core/pull/44, and https://github.com/returntocorp/ocaml-tree-sitter-core/pull/45. These allow the Swift grammar to parse emoji and fix the issue with core that prevented extras from appearing in other rules. So, I was also able to remove the `_class_member_separator` hack which led to a test failure.

Test plan: from `lang`: `./test-lang swift` passes without any errors.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
