### PR TITLE
Use new setup with local tree-sitter install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,6 @@ jobs:
           name: set up node
           command: ./core/scripts/setup-node
       - run:
-          name: install tree-sitter runtime library
-          command: ./core/scripts/install-tree-sitter-lib
-      - run:
-          name: install tree-sitter executable
-          command: ./core/scripts/install-tree-sitter-cli
-      - run:
           name: install dependencies
           command: opam exec -- make setup
       - run:

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,9 @@ setup:
 update:
 	git submodule update --init --recursive --depth 1
 
-# Keep things like node_modules that are worth keeping around
 .PHONY: clean
 clean:
 	rm -rf bin
-	dune clean
-	make -C tests clean
 	make -C lang clean
 
 .PHONY: distclean

--- a/lang/semgrep-grammars/src/Makefile.common
+++ b/lang/semgrep-grammars/src/Makefile.common
@@ -2,11 +2,13 @@
 # Generic makefile to be symlinked or to be included at the root of the
 # semgrep-* folders as follows:
 #
-#   include ../common.mk
+#   include ../Makefile.common
 #
 
 PROJECT_ROOT = $(shell git rev-parse --show-toplevel)
 NAME = $(shell pwd | xargs basename)
+
+include $(PROJECT_ROOT)/tree-sitter-config.mk
 
 # The folder containing the tree-sitter-* repos and semgrep-* folders
 NODE_PATH := $(PROJECT_ROOT)/lang/semgrep-grammars/src:$(NODE_PATH) make

--- a/tree-sitter-config.mk
+++ b/tree-sitter-config.mk
@@ -1,0 +1,1 @@
+core/tree-sitter-config.mk


### PR DESCRIPTION
Uses https://github.com/returntocorp/ocaml-tree-sitter-core/pull/46

### Security

- [x] Change has no security implications (otherwise, ping the security team)
