### PR TITLE
fix(test): Exit with error code on failed sublang test

### DIFF
--- a/lang/semgrep-grammars/src/Makefile.common
+++ b/lang/semgrep-grammars/src/Makefile.common
@@ -38,6 +38,7 @@ prep:
 
 .PHONY: test
 test:
+	set -e; \
 	for dir in $$(find . | grep 'grammar.js$$' | xargs -L1 dirname); do \
 	  echo "Test $$dir"; \
 	  (cd "$$dir" && tree-sitter test); \


### PR DESCRIPTION
Without `set -e`, it looks like the shell which Make spawns to run the
for loop just returns whatever exit code the last thing that runs has.
By adding `set -e` (and making it part of the same Bash command as the
for loop), Bash will exit with an error code as soon as anything fails.

Test plan: Add a failing corpus test to tsx. Note that before this
change, `./test-lang typescript` prints the failure, but continues on
and eventually exits 0. With this change, it aborts after the failure
with exit code 2.

Fixes #335

### Security

- [x] Change has no security implications (otherwise, ping the security team)
