### PR TITLE
java: Parse semgrep extensions

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-java/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-java/grammar.js
@@ -10,6 +10,12 @@ module.exports = grammar(base_grammar, {
   name: 'java',
 
   conflicts: ($, previous) => previous.concat([
+    // Conflict due to the addition of semgrep ellipsis to both. Can occur in
+    // switch bodies where you would need lookahead to disambiguate between a
+    // switch_label where the expression is a lambda and a switch_rule. There
+    // are already several conflicts in the original grammar to deal with this
+    // case.
+    [$.primary_expression, $.formal_parameter],
   ]),
 
   /*
@@ -17,15 +23,24 @@ module.exports = grammar(base_grammar, {
      if they're not already part of the base grammar.
   */
   rules: {
-  /*
+    // Additional rules for constructs that are not, by themselves, valid Java
+    // programs, but which should be valid Semgrep patterns.
+    program: ($, previous) => choice(
+      previous,
+      $.constructor_declaration,
+      $.expression,
+    ),
+
     semgrep_ellipsis: $ => '...',
 
-    _expression: ($, previous) => {
-      return choice(
-        $.semgrep_ellipsis,
-        ...previous.members
-      );
-    }
-  */
+    primary_expression: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    formal_parameter: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
@@ -1,0 +1,75 @@
+================================================================================
+Ellipsis
+================================================================================
+
+...
+
+--------------------------------------------------------------------------------
+
+(program
+  (semgrep_ellipsis))
+
+================================================================================
+Top level public constructor
+================================================================================
+
+public Foo(...) { }
+
+--------------------------------------------------------------------------------
+
+(program
+  (constructor_declaration
+    (modifiers)
+    (identifier)
+    (formal_parameters
+      (formal_parameter
+        (semgrep_ellipsis)))
+    (constructor_body)))
+
+================================================================================
+Top level bare constructor
+================================================================================
+
+Foo(...) { }
+
+--------------------------------------------------------------------------------
+
+(program
+  (constructor_declaration
+    (identifier)
+    (formal_parameters
+      (formal_parameter
+        (semgrep_ellipsis)))
+    (constructor_body)))
+
+================================================================================
+Metavariable
+================================================================================
+
+class $X {
+  $X() { }
+  void $ASDF() {
+    int $QWERTY = $UIOP;
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (class_declaration
+    (identifier)
+    (class_body
+      (constructor_declaration
+        (identifier)
+        (formal_parameters)
+        (constructor_body))
+      (method_declaration
+        (void_type)
+        (identifier)
+        (formal_parameters)
+        (block
+          (local_variable_declaration
+            (integral_type)
+            (variable_declarator
+              (identifier)
+              (identifier))))))))


### PR DESCRIPTION
Currently we use pfff to parse Java patterns. Unfortunately, due to an
issue I do not fully understand, it is unable to parse the pattern
`public Foo() { }`, which is a standalone constructor with a privacy
modifier. It looks like the grammar should allow this, and in fact it
does allow patterns like `Foo() { }`. There is already a hack in place
to address an LR(1) conflict, and I suspect that it is not working as
desired. Rather than debug the issue with the pfff parser, I think it
makes sense to switch to using the tree sitter parser as a fallback for
pattern parsing like I recently did for JS/TS.

This does the minimum to support the basic Semgrep pattern extensions
(ellipsis in a few positions and tests verifying that metavariables
parse), as well as the constructor case that does not work correctly in
the pfff parser.

Helps https://github.com/returntocorp/semgrep/issues/5558

Test plan: Automated tests, plus testing of integration with semgrep
(already done, but PR not yet up).

### Security

- [x] Change has no security implications (otherwise, ping the security team)
