### PR TITLE
Add safeguard to release command when no language is given

### DIFF
--- a/lang/release
+++ b/lang/release
@@ -57,6 +57,10 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+if [[ -z "$lang" ]]; then
+  error "Missing language. See --help for usage."
+fi
+
 id=$(git rev-parse --short HEAD)
 
 if [[ "$dry_run" = false ]]; then


### PR DESCRIPTION
### Security

- [x] Change has no security implications (otherwise, ping the security team)
