### PR TITLE
chore: Update tree-sitter-swift and work around custom operator issue

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-swift/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-swift/grammar.js
@@ -11,6 +11,7 @@ module.exports = grammar(base_grammar, {
 
   conflicts: ($, previous) => previous.concat([
     [$._three_dot_operator, $.semgrep_expression_ellipsis],
+    [$._three_dot_operator, $.semgrep_expression_ellipsis, $.semgrep_ellipsis],
   ]),
 
   /*
@@ -22,11 +23,14 @@ module.exports = grammar(base_grammar, {
     // are parsing a pattern, we will convert that into an ellipsis after it's
     // parsed, but let's use low precedence here so that normally we only
     // produce this node where the unbounded range operator cannot exist.
-    semgrep_expression_ellipsis: $ => prec.dynamic(-1337, $._three_dot_operator_custom),
+    semgrep_expression_ellipsis: $ => prec.dynamic(-1337, "..."),
 
+    // Use "..." here and in semgrep_expression_ellipsis above, rather than
+    // `$._three_dot_operator`, so that the conflicts list is easier to
+    // understand.
     semgrep_ellipsis: $ => "...",
 
-    semgrep_deep_ellipsis: $ => seq("<...", $._expression, "...>"),
+    semgrep_deep_ellipsis: $ => seq("<...", $._expression, $.custom_operator),
 
     _expression: ($, previous) => choice(
       previous,

--- a/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
@@ -89,7 +89,35 @@ Deep Ellipsis
 
 --------------------------------------------------------------------------------
 
-(source_file (semgrep_deep_ellipsis (integer_literal)))
+(source_file (semgrep_deep_ellipsis (integer_literal) (custom_operator)))
+
+================================================================================
+Deep Ellipsis with custom operator (should not parse, but does because of a hack
+necessary to work around custom operators getting scanned by the custom scanner)
+================================================================================
+
+<... 5 .+.
+
+--------------------------------------------------------------------------------
+
+(source_file (semgrep_deep_ellipsis (integer_literal) (custom_operator)))
+
+================================================================================
+Deep Ellipsis with custom operator (this parses due to parens)
+================================================================================
+
+<... (5 .+. 3) ...>
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_deep_ellipsis
+    (tuple_expression
+      (infix_expression
+        (integer_literal)
+        (custom_operator)
+        (integer_literal)))
+    (custom_operator)))
 
 ================================================================================
 Class Ellipsis
@@ -116,3 +144,29 @@ class ClassName {
 --------------------------------------------------------------------------------
 
 (source_file (class_declaration (type_identifier) (class_body (semgrep_ellipsis) (property_declaration (pattern (simple_identifier)) (integer_literal)) (semgrep_ellipsis))))
+
+================================================================================
+Statement Ellipsis with semicolon
+================================================================================
+
+foo;
+...
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (simple_identifier)
+  (fully_open_range))
+
+================================================================================
+Statement Ellipsis without semicolon
+================================================================================
+
+foo
+...
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (simple_identifier)
+  (fully_open_range))


### PR DESCRIPTION
Notably, this pulls in:
* Using the external scanner to handle custom operators: https://github.com/alex-pinkus/tree-sitter-swift/commit/c17937810b59388e818ffb493a45fe424b85698c
* No longer using the external scanner to handle "...": https://github.com/alex-pinkus/tree-sitter-swift/commit/f58deb71df91bcee6d650774dbd136a7493ca20f

# Custom operator change:

Unfortunately, `...>` is a valid custom operator in Swift, and it can occur as part of an expression. So, for the pattern `<... 5 ...>`, it gets lexed as `<...`, followed by the expression `5`, followed by a `custom_operator` token. This doesn't fit the deep ellipsis rule, so it results in a parse error.

A proper fix would be to extend the scanner so that `...>` is its own token, and then handle it separately in the grammar. This would be complicated, and would likely present significant maintainability challenges because the way custom scanners are structured does not invite extensibility. We would probably have to maintain a fork of the scanner.

Instead, I propose this hack. Unfortunately, it will prevent people from writing patterns like `<... 5 .+. 1 ...>` because the custom operator in the middle will get mistaken for the end of the deep ellipsis. However, this can easily be worked around with parentheses, and it's probably going to come up rarely, if ever.

When incorporating this into Semgrep, I plan to check to ensure that the text of the custom operator is `...>` and fail if not. This way, we won't have backwards-compatibility issues if we do this better in the future due to people inadvertently writing `..>` or the like.

# "..." change:

This change involved making a few tweaks to our grammar extensions, but nothing really major. The big thing that this changes is that now the following program is parsed as an identifier followed by, as a separate statement, a fully open range:

```
foo
...
```

When parsing a Semgrep pattern, we convert a fully open range into a Semgrep ellipsis. So, when used as a pattern, this will mean "the statement `foo` followed by any number of statements`, which aligns with user expectations. Previously, it was parsed as a single expression statement: an open-ended range.

Test plan: Automated tests

### Security

- [x] Change has no security implications (otherwise, ping the security team)
