### PR TITLE
C++: start support semgrep patterns (metavar and simple ellipsis)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-cpp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-cpp/grammar.js
@@ -10,6 +10,10 @@ module.exports = grammar(base_grammar, {
   name: 'cpp',
 
   conflicts: ($, previous) => previous.concat([
+      // C++ allows 'sizeof ...(id)' hence the conflict
+      [$.sizeof_expression, $.semgrep_ellipsis],
+      // C allows ... in parameters
+      [$.parameter_list, $.semgrep_ellipsis],
   ]),
 
   /*
@@ -17,15 +21,30 @@ module.exports = grammar(base_grammar, {
      if they're not already part of the base grammar.
   */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
+    // Metavariables
+
+    /* we can't use the usual:
+
+	 identifier: ($, prev) => { return choice(prev, $._semgrep_metavariable);},
+         _semgrep_metavariable: $ => /\$[A-Z_][A-Z_0-9]* /,
+
+      because in tree-sitter-c 'identifier' is used in the 'word:' directive and
+      'identifier' then can't be a non-terminal. In other languages this is solved
+      by having 'identifier' and a separate '_identifier_token' (e.g., in C#)
+    */
+    identifier: $ => /\$?[a-zA-Z_]\w*/, // original = /[a-zA-Z_]\w*/
+
+    // Ellipsis
 
     _expression: ($, previous) => {
       return choice(
+        previous,
         $.semgrep_ellipsis,
-        ...previous.members
+        $.deep_ellipsis,
       );
-    }
-  */
+    },
+	
+    semgrep_ellipsis: $ => '...',
+    deep_ellipsis: $ => seq('<...', $._expression, '...>'),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-cpp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-cpp/test/corpus/semgrep.txt
@@ -1,0 +1,28 @@
+=====================================
+Metavariables
+=====================================
+$VAR = 1;
+
+---
+(translation_unit
+      (expression_statement
+        (assignment_expression
+          (identifier)
+          (number_literal))))
+
+=====================================
+Ellipsis for expression
+=====================================
+
+$VAR->$MEMBER = ...;
+
+---
+
+(translation_unit
+      (expression_statement
+        (assignment_expression
+          (field_expression
+            (identifier)
+            (field_identifier))
+          (semgrep_ellipsis))))
+


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1923

test plan:
test file included
./test-lang cpp


### Security

- [x] Change has no security implications (otherwise, ping the security team)