### PR TITLE
Use the correct path to tree-sitter when querying it for its version.

### DIFF
--- a/lang/release
+++ b/lang/release
@@ -115,7 +115,10 @@ copy_fyi_files() {
 
     mkdir -p "$fyi_dst"
 
-    tree-sitter --version > "$fyi_dst"/tree-sitter-version
+    # It would be nice if the path to tree-sitter came from an included
+    # config file but we only have an includable makefile at the moment.
+    ../core/tree-sitter/bin/tree-sitter --version \
+      > "$fyi_dst"/tree-sitter-version
 
     # Record the git commit of each "FYI" file.
     version_file="$fyi_dst"/versions


### PR DESCRIPTION
This was using whichever `tree-sitter` executable was in my PATH, resulting in publishing the wrong version of tree-sitter in the "FYI" files, even though the files were correctly generated with the local version of `tree-sitter`.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
