### PR TITLE
Copy and adapt Semgrep extensions for Java to Apex, including tests.

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-java/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-java/grammar.js
@@ -2,6 +2,8 @@
   semgrep-java
 
   Extends the standard java grammar with semgrep pattern constructs.
+  Note that '$' is valid character in Java identifiers so we don't
+  need to extend the grammar to support metavariables such as '$FOO'.
 */
 
 const base_grammar = require('tree-sitter-java/grammar');
@@ -32,10 +34,6 @@ module.exports = grammar(base_grammar, {
     [$.primary_expression, $.statement],
   ]),
 
-  /*
-     Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
-     if they're not already part of the base grammar.
-  */
   rules: {
     // Additional rules for constructs that are not, by themselves, valid Java
     // programs, but which should be valid Semgrep patterns.

--- a/lang/semgrep-grammars/src/semgrep-sfapex/apex/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-sfapex/apex/grammar.js
@@ -1,7 +1,13 @@
 /*
   semgrep-sfapex
 
-  Extends the standard sfapex grammar with semgrep pattern constructs.
+  Extends the standard sfapex grammar:
+  - with semgrep pattern constructs ('$FOO', '...', ...)
+  - with alternate entrypoints allowing simple code fragments to be parsed
+    as semgrep patterns
+
+  This work derives from what we have for Java in
+  ../semgrep-java/grammar.js
 */
 
 const base_grammar = require('tree-sitter-sfapex/apex/grammar');
@@ -9,21 +15,37 @@ const base_grammar = require('tree-sitter-sfapex/apex/grammar');
 module.exports = grammar(base_grammar, {
   name: 'apex',
 
+  // See explanations in semgrep-java/grammar.js
   conflicts: ($, previous) => previous.concat([
+    [$.primary_expression, $.formal_parameter],
+    [$.primary_expression, $.statement],
   ]),
 
-  /*
-     Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
-     if they're not already part of the base grammar.
-  */
   rules: {
-  /*
+    // Entrypoint. We add alternate entrypoints for Semgrep patterns.
+    parser_output: ($, previous) => choice(
+      // Replace repeat($.declaration) which is too limited. (need to clarify)
+      repeat($.statement),
+
+      $.constructor_declaration,
+      $.expression,
+    ),
+
     semgrep_ellipsis: $ => '...',
 
-    _expression: ($, previous) => choice(
+    primary_expression: ($, previous) => choice(
+      previous,
       $.semgrep_ellipsis,
-      ...previous.members
     ),
-  */
+
+    statement: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    formal_parameter: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-sfapex/apex/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-sfapex/apex/test/corpus/semgrep.txt
@@ -1,0 +1,151 @@
+================================================================================
+Ellipsis
+================================================================================
+
+...
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (semgrep_ellipsis))
+
+================================================================================
+Top level statements
+================================================================================
+
+foo();
+...
+bar();
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (expression_statement
+    (method_invocation
+      (identifier)
+      (argument_list)))
+  (semgrep_ellipsis)
+  (expression_statement
+    (method_invocation
+      (identifier)
+      (argument_list))))
+
+================================================================================
+Top level public constructor
+================================================================================
+
+public Foo(...) { }
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (constructor_declaration
+    (modifiers
+      (modifier))
+    (identifier)
+    (formal_parameters
+      (formal_parameter
+        (semgrep_ellipsis)))
+    (constructor_body)))
+
+================================================================================
+Top level bare constructor
+================================================================================
+
+Foo(...) { }
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (constructor_declaration
+    (identifier)
+    (formal_parameters
+      (formal_parameter
+        (semgrep_ellipsis)))
+    (constructor_body)))
+
+================================================================================
+Constructor body ellipsis
+================================================================================
+
+public Foo(...) {
+  ...
+}
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (constructor_declaration
+    (modifiers
+      (modifier))
+    (identifier)
+    (formal_parameters
+      (formal_parameter
+        (semgrep_ellipsis)))
+    (constructor_body
+      (semgrep_ellipsis))))
+
+================================================================================
+Ellipsis args
+================================================================================
+
+foo(..., 5)
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (method_invocation
+    (identifier)
+    (argument_list
+      (semgrep_ellipsis)
+      (int))))
+
+================================================================================
+Ellipsis in if
+================================================================================
+
+if (...) {
+  ...
+}
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (if_statement
+    (parenthesized_expression
+      (semgrep_ellipsis))
+    (block
+      (semgrep_ellipsis))))
+
+================================================================================
+Metavariable
+================================================================================
+
+class $X {
+  $X() { }
+  void $ASDF() {
+    int $QWERTY = $UIOP;
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (class_declaration
+    (identifier)
+    (class_body
+      (constructor_declaration
+        (identifier)
+        (formal_parameters)
+        (constructor_body))
+      (method_declaration
+        (void_type)
+        (identifier)
+        (formal_parameters)
+        (block
+          (local_variable_declaration
+            (type_identifier)
+            (variable_declarator
+              (identifier)
+              (assignment_operator)
+              (identifier))))))))


### PR DESCRIPTION
This will allow simple snippets such as expressions to be used as Semgrep patterns.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
