### PR TITLE
Generate semgrep-apex as part of a different dune package

### DIFF
--- a/lang/release
+++ b/lang/release
@@ -61,6 +61,15 @@ if [[ -z "$lang" ]]; then
   error "Missing language. See --help for usage."
 fi
 
+# Language-specific options
+GEN_OCAML_OPTIONS=""
+case "$lang" in
+  apex)
+    GEN_OCAML_OPTIONS="--package tree-sitter-lang-pro"
+    ;;
+  *)
+esac
+
 id=$(git rev-parse --short HEAD)
 
 if [[ "$dry_run" = false ]]; then
@@ -156,7 +165,7 @@ git -C "$export_dir/$repo" pull origin "$branch" --ff-only
 # Copy the files that we find.
 #
 make -C "$lang" clean
-make -C "$lang" gen
+make -C "$lang" GEN_OCAML_OPTIONS="$GEN_OCAML_OPTIONS" gen
 dst="$export_dir"/"$repo"
 if [[ -d "$lang"/ocaml-src ]]; then
   cp -a "$lang"/ocaml-src/lib "$dst"


### PR DESCRIPTION
Uses https://github.com/returntocorp/ocaml-tree-sitter-core/pull/56 to put semgrep-apex into a different dune package, allowing us to have it as a git submodule directly in semgrep-proprietary rather than being forced to have with all the other parsers in the semgrep repo.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
