### PR TITLE
Support partial 'if' only at top level

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-sfapex/apex/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-sfapex/apex/grammar.js
@@ -49,9 +49,10 @@ module.exports = grammar(base_grammar, {
       $._full_method_header,
 
       // Partial statements
+      seq(ci("if"), $.parenthesized_expression),
       seq(ci("try"), $.block),
       seq(ci("catch"), $.catch_clause),
-      $.finally_clause,
+      $.finally_clause
     ),
 
     semgrep_ellipsis: $ => '...',
@@ -190,22 +191,6 @@ module.exports = grammar(base_grammar, {
     _full_method_header: ($) => seq(
       optional($.modifiers),
       $._method_header,
-    ),
-
-    // Rewrite if_statement to support partial construct: if(cond)
-    if_statement: ($) => prec.right(
-      seq(
-        ci("if"),
-        $.parenthesized_expression,
-        optional($._consequences)
-      )
-    ),
-
-    _consequences: ($) => prec.right(
-      seq(
-        $.statement,
-        optional(seq(ci("else"), field("alternative", $.statement)))
-      )
     ),
 
 /*

--- a/lang/semgrep-grammars/src/semgrep-sfapex/apex/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-sfapex/apex/grammar.js
@@ -49,11 +49,16 @@ module.exports = grammar(base_grammar, {
       $._full_method_header,
 
       // Partial statements
-      seq(ci("if"), $.parenthesized_expression),
-      seq(ci("try"), $.block),
-      seq(ci("catch"), $.catch_clause),
-      $.finally_clause
+      $.partial_if,
+      $.partial_try,
+      $.partial_catch,
+      $.partial_finally
     ),
+
+    partial_if: ($) => seq(ci("if"), $.parenthesized_expression),
+    partial_try: ($) => seq(ci("try"), $.block),
+    partial_catch: ($) => $.catch_clause,
+    partial_finally: ($) => $.finally_clause,
 
     semgrep_ellipsis: $ => '...',
     semgrep_metavar_ellipsis: $ => /\$\.\.\.[A-Z_][A-Z_0-9]*/,

--- a/lang/semgrep-grammars/src/semgrep-sfapex/apex/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-sfapex/apex/test/corpus/semgrep.txt
@@ -328,7 +328,7 @@ iF (true)
 ---
 
 (parser_output
-  (if_statement
+  (partial_if
     (parenthesized_expression
       (boolean))))
 
@@ -343,31 +343,41 @@ tRy {
 ---
 
 (parser_output
-  (block
-    (expression_statement
-      (dml_expression
-        (dml_type)
-        (identifier)))))
+  (partial_try
+    (block
+      (expression_statement
+        (dml_expression
+          (dml_type)
+          (identifier))))))
 
 ==========================================
-'finally' clause
+Lone 'catch'
 ==========================================
 
-finallY {
-  Boolean finallyRan = true;
-}
+caTch(DmlException e) {}
 
 ---
 
 (parser_output
-  (finally_clause
-    (block
-      (local_variable_declaration
+  (partial_catch
+    (catch_clause
+      (catch_formal_parameter
         (type_identifier)
-        (variable_declarator
-          (identifier)
-          (assignment_operator)
-          (boolean))))))
+        (identifier))
+      (block))))
+
+==========================================
+Lone 'finally'
+==========================================
+
+finallY {}
+
+---
+
+(parser_output
+  (partial_finally
+    (finally_clause
+      (block))))
 
 ==========================================
 Ellipsis for type parameters


### PR DESCRIPTION
I originally had problems with having some partial constructs only at the top level. This simple solution works, though.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
