### PR TITLE
switch to github.com/returntocorp/tree-sitter-jsonnet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -84,7 +84,7 @@
 	url = https://github.com/tree-sitter/tree-sitter-julia
 [submodule "lang/semgrep-grammars/src/tree-sitter-jsonnet"]
 	path = lang/semgrep-grammars/src/tree-sitter-jsonnet
-	url = https://github.com/sourcegraph/tree-sitter-jsonnet.git
+	url = https://github.com/returntocorp/tree-sitter-jsonnet.git
 [submodule "lang/semgrep-grammars/src/tree-sitter-sfapex"]
 	path = lang/semgrep-grammars/src/tree-sitter-sfapex
 	url = https://github.com/aheber/tree-sitter-sfapex.git


### PR DESCRIPTION
The maintainer of the original
https://github.com/sourcegraph/tree-sitter-jsonnet is quite
responsive, but it's still faster to use our own repo than
wait for approval

test plan:
make test


### Security

- [x] Change has no security implications (otherwise, ping the security team)