### PR TITLE
Solidity: fix ellipsis in contract inheritance

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
@@ -90,6 +90,13 @@ module.exports = grammar(base_grammar, {
             );
         },
 
+        inheritance_specifier: ($, previous) => {
+            return choice(
+                previous,
+                $.ellipsis
+            );
+        },
+
       // The actual ellipsis rules
         deep_ellipsis: $ => seq(
             '<...', $._expression, '...>'

--- a/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
@@ -56,3 +56,20 @@ modifier $M(...) {
         (function_body
           (expression_statement
             (ellipsis)))))
+
+=====================================
+Inheritance ellipsis pattern
+=====================================
+contract Example is ..., BoringBatchable, ... {}
+---
+(source_file
+  (contract_declaration
+    (identifier)
+    (inheritance_specifier
+      (ellipsis))
+    (inheritance_specifier
+      (user_defined_type
+        (identifier)))
+    (inheritance_specifier
+      (ellipsis))
+  (contract_body)))


### PR DESCRIPTION
### Description
Right now if a contract inherits several other contracts, it is not possible to find a specific one, e.g. this rule will not match:

```solidity
contract A is B, C, D {}
```
```yaml
- pattern: contract $A is C { ... }
```
Ellipsis will give an error:
```yaml
- pattern: contract $A is ..., C, ... { ... }
```
This PR resolves parsing error and hopefully allows to match specific inherited contracts using ellipsis.
### Security

- [x] Change has no security implications (otherwise, ping the security team)
