### PR TITLE
Jsonnet: add metavar and ellipsis for jsonnet

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-jsonnet/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-jsonnet/grammar.js
@@ -14,16 +14,41 @@ module.exports = grammar(base_grammar, {
 
   /*
      Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
-     if they're not already part of the base grammar.
   */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
+    // No need for _SEMGREP_EXPRESSION hack here, because jsonnet allows
+    // toplevel expressions.
+      
+    // Metavariables
+    id: ($, previous) => {
+      return choice(
+        previous,
+        $._semgrep_metavariable
+      );
+    },
 
-    _expression: ($, previous) => choice(
+    _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
+
+    // Ellipsis
+    expr: ($, previous) => choice(
       $.semgrep_ellipsis,
-      ...previous.members
+      $.deep_ellipsis,
+      previous
     ),
-  */
+    field: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      previous
+    ),
+    param: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      previous
+    ),
+
+    // The actual ellipsis rules
+    semgrep_ellipsis: $ => '...',
+      
+    deep_ellipsis: $ => seq(
+            '<...', $.expr, '...>'
+    ),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-jsonnet/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-jsonnet/test/corpus/semgrep.txt
@@ -1,0 +1,132 @@
+=====================================
+Metavariables
+=====================================
+
+$FOO(1, 2)
+
+---
+
+(document
+      (expr
+        (expr
+          (id))
+        (args
+          (expr
+            (number))
+          (expr
+            (number)))))
+
+=====================================
+Ellipsis in calls
+=====================================
+
+foo(...)
+
+---
+
+(document
+      (expr
+        (expr
+          (id))
+        (args
+          (expr
+            (semgrep_ellipsis)))))
+
+
+
+=====================================
+Ellipsis in arrays
+=====================================
+[1, 2, ...]
+
+---
+(document
+      (expr
+        (expr
+          (number))
+        (expr
+          (number))
+        (expr
+          (semgrep_ellipsis))))
+
+=====================================
+Ellipsis in objects
+=====================================
+{ a: 1, ..., b: 3 }
+
+---
+(document
+      (expr
+        (member
+          (field
+            (fieldname
+              (id))
+            (expr
+              (number))))
+        (member
+          (field
+            (semgrep_ellipsis)))
+        (member
+          (field
+            (fieldname
+              (id))
+            (expr
+              (number))))))
+
+
+=====================================
+Ellipsis in parameter
+=====================================
+
+local x = function(a, ..., b) { ... };
+x(1,2,3)
+
+---
+   (document
+      (expr
+        (local_bind
+          (local)
+          (bind
+            (id)
+            (expr
+              (anonymous_function
+                (params
+                  (param
+                    (id))
+                  (param
+                    (semgrep_ellipsis))
+                  (param
+                    (id)))
+                (expr
+                  (member
+                    (field
+                      (semgrep_ellipsis)))))))
+          (expr
+            (expr
+              (id))
+            (args
+              (expr
+                (number))
+              (expr
+                (number))
+              (expr
+                (number)))))))
+
+=====================================
+Deep Ellipsis
+=====================================
+
+
+foo(<... 3 ...>)
+
+---
+(document
+      (expr
+        (expr
+          (id))
+        (args
+          (expr
+            (deep_ellipsis
+              (expr
+                (number)))))))
+


### PR DESCRIPTION
I need to make a PR for the tree-sitter-jsonnet patch.

test plan:
./test-lang jsonnet


### Security

- [x] Change has no security implications (otherwise, ping the security team)