### PR TITLE
XML: add support for xml by tweaking semgrep-html

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-html/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-html/grammar.js
@@ -1,7 +1,12 @@
 /*
   semgrep-html
 
-  Extends the standard html grammar with semgrep pattern constructs.
+  Extends the standard HTML grammar with Semgrep pattern constructs.
+
+  It now also extend the HTML grammar with XML constructs! See scanner_cc.diff
+  for the extension to the scanner to support XML entity names (e.g., <f:bar></f:bar>).
+  An alternative would be to switch to https://github.com/unhammer/tree-sitter-xml,
+  but its grammar looks very complicated and the code is not maintained.
 */
 
 const base_grammar = require('tree-sitter-html/grammar');
@@ -17,7 +22,20 @@ module.exports = grammar(base_grammar, {
      valid HTML syntax in many places, so we don't need that many
      grammar extensions
   */
-  rules: {
+    rules: {
+
+    // XML extensions
+    _node: ($, previous) => choice(
+       $.xmldoctype,
+       previous
+    ),
+    
+    xmldoctype: $ => seq(
+      '<?xml',
+      repeat($.attribute),
+      '?>'
+    ),
+	
     //alt: redefine instead _start_tag_name and _end_tag_name?
     start_tag: ($, previous) => choice(
       $.semgrep_start_tag,
@@ -42,6 +60,5 @@ module.exports = grammar(base_grammar, {
     ),
 
     semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
-      
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-html/prep
+++ b/lang/semgrep-grammars/src/semgrep-html/prep
@@ -11,8 +11,10 @@ mkdir -p src
 (
   cd src
   rm -f scanner.cc
-  ln -sf ../../tree-sitter-html/src/scanner.cc scanner.cc
+  cp ../../tree-sitter-html/src/scanner.cc scanner.cc
 )
+# to extend the HTML lexer to also accept XML tags
+patch -p1 < scanner_cc.diff
 
 (
   cd src

--- a/lang/semgrep-grammars/src/semgrep-html/scanner_cc.diff
+++ b/lang/semgrep-grammars/src/semgrep-html/scanner_cc.diff
@@ -1,0 +1,16 @@
+diff -u a/src/scanner.cc b/src/scanner.cc
+--- a/src/scanner.cc	2023-02-03 11:48:23.490095119 +0100
++++ b/scanner.cc	2023-02-03 11:41:46.390092778 +0100
+@@ -82,6 +82,10 @@
+   string scan_tag_name(TSLexer *lexer) {
+     string tag_name;
+     while (iswalnum(lexer->lookahead) ||
++	   // to accept xml names!
++           lexer->lookahead == '.' ||
++           lexer->lookahead == '_' ||
++	   // original html-only name
+            lexer->lookahead == '-' ||
+            lexer->lookahead == ':') {
+       tag_name += towupper(lexer->lookahead);
+
+Diff finished.  Fri Feb  3 11:48:46 2023

--- a/lang/semgrep-grammars/src/semgrep-html/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-html/test/corpus/semgrep.txt
@@ -62,3 +62,31 @@ Ellipsis in attributes and body
      (start_tag (tag_name) (attribute (attribute_name)))
      (raw_text)
      (end_tag (tag_name))))
+
+===================================
+XML constructs
+===================================
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"></xs:schema>
+
+---
+(fragment
+      (xmldoctype
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value)))
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value))))
+      (element
+        (start_tag
+          (tag_name)
+          (attribute
+            (attribute_name)
+            (quoted_attribute_value
+              (attribute_value))))
+        (end_tag
+          (tag_name))))


### PR DESCRIPTION
test plan:
./test-lang html
./html/parse-html ~/pom.xml
which works


### Security

- [ ] Change has no security implications (otherwise, ping the security team)