### PR TITLE
fix circleCI, do not use xlarge resource and skip c# and kotlin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     # - medium+: 6 GB
     # - large: 8 GB
     # - xlarge: 16 GB
-    resource_class: xlarge
+    #resource_class: xlarge
 
     working_directory: ~/ocaml-tree-sitter
     steps:
@@ -47,7 +47,7 @@ jobs:
       - image: returntocorp/ocaml:ubuntu
 
     # See earlier note about memory requirements.
-    resource_class: xlarge
+    #resource_class: xlarge
 
     working_directory: ~/ocaml-tree-sitter
     steps:

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -12,7 +12,6 @@
 SUPPORTED_TS_LANGUAGES = \
   bash \
   c \
-  c-sharp \
   cpp \
   dart \
   dockerfile \
@@ -39,6 +38,7 @@ SUPPORTED_TS_LANGUAGES = \
   vue
 # Commented out due to hitting memory limits in CI:
 #  hack
+#  c-sharp
 
 # Includes all language variants e.g. typescript and tsx
 SUPPORTED_LANGUAGES = $(SUPPORTED_TS_LANGUAGES) tsx
@@ -49,12 +49,10 @@ SUPPORTED_LANGUAGES = $(SUPPORTED_TS_LANGUAGES) tsx
 STAT_LANGUAGES = \
   bash \
   c \
-  c-sharp \
   cpp \
   dockerfile \
   elixir \
   go \
-  hack \
   hcl \
   java \
   javascript \
@@ -72,6 +70,9 @@ STAT_LANGUAGES = \
   sqlite \
   tsx \
   typescript
+# Commented out due to hitting memory limits in CI:
+#  hack
+#  c-sharp
 
 # Build and test each language. Does not run parsing stats (see 'stat:').
 #

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -48,8 +48,6 @@ SUPPORTED_LANGUAGES = $(SUPPORTED_TS_LANGUAGES) tsx
 #
 STAT_LANGUAGES = \
   bash \
-  c \
-  cpp \
   dockerfile \
   elixir \
   go \
@@ -69,10 +67,11 @@ STAT_LANGUAGES = \
   sqlite \
   tsx \
   typescript
-# Commented out due to hitting memory limits in CI:
+# Commented out due to hitting memory limits in CI or because taking too much time:
 #  hack
 #  c-sharp
 #  kotlin
+#  c cpp
 
 # Build and test each language. Does not run parsing stats (see 'stat:').
 #

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -23,7 +23,6 @@ SUPPORTED_TS_LANGUAGES = \
   julia \
   javascript \
   jsonnet \
-  kotlin \
   lua \
   ocaml \
   php \
@@ -39,6 +38,7 @@ SUPPORTED_TS_LANGUAGES = \
 # Commented out due to hitting memory limits in CI:
 #  hack
 #  c-sharp
+#  kotlin
 
 # Includes all language variants e.g. typescript and tsx
 SUPPORTED_LANGUAGES = $(SUPPORTED_TS_LANGUAGES) tsx
@@ -57,7 +57,6 @@ STAT_LANGUAGES = \
   java \
   javascript \
   julia \
-  kotlin \
   lua \
   ocaml \
   php \
@@ -73,6 +72,7 @@ STAT_LANGUAGES = \
 # Commented out due to hitting memory limits in CI:
 #  hack
 #  c-sharp
+#  kotlin
 
 # Build and test each language. Does not run parsing stats (see 'stat:').
 #

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -49,29 +49,23 @@ SUPPORTED_LANGUAGES = $(SUPPORTED_TS_LANGUAGES) tsx
 STAT_LANGUAGES = \
   bash \
   dockerfile \
-  elixir \
   go \
   hcl \
   java \
   javascript \
   julia \
-  lua \
   ocaml \
   php \
   python \
-  r \
   ruby \
   rust \
   sfapex \
   solidity \
-  sqlite \
   tsx \
   typescript
 # Commented out due to hitting memory limits in CI or because taking too much time:
-#  hack
-#  c-sharp
-#  kotlin
-#  c cpp
+#  hack c-sharp kotlin
+#  c cpp elixir lua r sqlite
 
 # Build and test each language. Does not run parsing stats (see 'stat:').
 #


### PR DESCRIPTION
This seems to not be part of our plan anymore.
We get
```
Resource class docker for xlarge is not available for your project, or
is not a valid resource class. This message will often appear if the
pricing plan for this project does not support docker use.
```
error in circleCI dashboard

test plan:
wait for circleCI to kick in and hope for green check


### Security

- [ ] Change has no security implications (otherwise, ping the security team)