### PR TITLE
typescript: Add HTML comments

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
+++ b/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
@@ -39,5 +39,24 @@ module.exports = {
       previous,
       $.semgrep_expression_ellipsis,
     ),
+
+    // TODO Remove this when we update tree-sitter-typescript past
+    // https://github.com/tree-sitter/tree-sitter-typescript/pull/239. I (nmote)
+    // ran into unrelated issues updating it, documented in
+    // https://linear.app/r2c/issue/PA-2572/address-error-when-updating-tree-sitter-typescript.
+    comment: ($, previous) => token(choice(
+      previous,
+      // https://tc39.es/ecma262/#sec-html-like-comments
+      seq('<!--', /.*/),
+      // This allows code to exist before this token on the same line.
+      //
+      // Technically, --> is supposed to have nothing before it on the same line
+      // except for comments and whitespace, but that is difficult to express,
+      // and in general tree sitter grammars tend to prefer to be overly
+      // permissive anyway.
+      //
+      // This approach does not appear to cause problems in practice.
+      seq('-->', /.*/)
+   )),
   }
 }

--- a/lang/semgrep-grammars/src/semgrep-typescript/typescript/corpus/html-comments.txt
+++ b/lang/semgrep-grammars/src/semgrep-typescript/typescript/corpus/html-comments.txt
@@ -1,0 +1,35 @@
+==========================================
+HTML Comments (not actually valid TS, but is valid JS)
+==========================================
+
+<!-- we can put whatever we like here. this affects one line only.
+y * z;
+<!-- and here as well. these do not have to have matching close comments.
+
+x + 1; --> for some reason you can put text after a close comment.
+
+--> note that the x + 1 above should be rejected according to the spec.
+--> it should instead be rejected as invalid.
+--> you are supposed to only have whitespace or comments before
+--> an HTML close comment.
+
+---
+
+(program
+  (comment)
+  (expression_statement
+    (binary_expression
+      (identifier)
+      (identifier)))
+  (comment)
+  (expression_statement
+    (binary_expression
+      (identifier)
+      (number)))
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment))
+
+


### PR DESCRIPTION
As noted inline, I would prefer to update tree-sitter-typescript, which now includes this change. Unfortunately, I ran into unrelated issues attempting that, so I'm adding the grammar change here directly for now.

Test plan: Automated tests

### Security

- [x] Change has no security implications (otherwise, ping the security team)
