### PR TITLE
feat!: add Standard ML language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "lang/semgrep-grammars/src/tree-sitter-clojure"]
 	path = lang/semgrep-grammars/src/tree-sitter-clojure
 	url = https://github.com/sogaiu/tree-sitter-clojure
+[submodule "lang/semgrep-grammars/src/tree-sitter-sml"]
+	path = lang/semgrep-grammars/src/tree-sitter-sml
+	url = https://github.com/MatthewFluet/tree-sitter-sml

--- a/lang/semgrep-grammars/lang/sml
+++ b/lang/semgrep-grammars/lang/sml
@@ -1,0 +1,1 @@
+../src/semgrep-sml

--- a/lang/semgrep-grammars/src/semgrep-sml/Makefile
+++ b/lang/semgrep-grammars/src/semgrep-sml/Makefile
@@ -1,0 +1,1 @@
+../Makefile.common

--- a/lang/semgrep-grammars/src/semgrep-sml/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-sml/grammar.js
@@ -1,0 +1,46 @@
+/*
+  semgrep-sml
+
+  Extends the standard sml grammar with semgrep pattern constructs.
+*/
+
+const base_grammar = require('tree-sitter-sml/grammar');
+
+module.exports = grammar(base_grammar, {
+  name: 'sml',
+
+  conflicts: ($, previous) => previous.concat([
+    [$.mrule, $._atpat]
+  ]),
+
+  /*
+     Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
+     if they're not already part of the base grammar.
+  */
+  rules: {
+    semgrep_ellipsis: $ => '...',
+
+    // As it turns out, $x parses as the application of `$` to an identifier.
+    // We'll just allow it to parse like that, and then fix it in generic translation.
+
+    _dec_no_local: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      previous
+    ),
+
+    _spec: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      previous
+    ),
+
+    _atpat: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      previous
+    ),
+    
+    mrule: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      previous
+    )
+  }
+});

--- a/lang/semgrep-grammars/src/semgrep-sml/prep
+++ b/lang/semgrep-grammars/src/semgrep-sml/prep
@@ -1,0 +1,1 @@
+../prep.common

--- a/lang/semgrep-grammars/src/semgrep-sml/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-sml/test/corpus/semgrep.txt
@@ -1,0 +1,205 @@
+=====================================
+Simple Metavariable 
+=====================================
+
+val x = $X
+
+---
+
+(source_file
+	(val_dec
+		(valbind
+			(vid_pat
+				(longvid
+					(vid)))
+			(app_exp
+				(vid_exp
+					(longvid
+						(vid)))
+				(vid_exp
+					(longvid
+						(vid)))))))
+
+=====================================
+Simple Metavariable Binding
+=====================================
+
+val $X = 2
+
+---
+
+(source_file
+	(val_dec
+		(valbind
+			(app_pat
+				(vid_pat
+					(longvid
+						(vid)))
+				(vid_pat
+					(longvid
+						(vid))))
+			(scon_exp
+				(integer_scon)))))
+
+=====================================
+Simple Ellipses
+=====================================
+
+val x = 
+	let
+    ...
+  in
+		4
+	end
+
+---
+
+(source_file
+	(val_dec
+		(valbind
+			(vid_pat
+				(longvid
+					(vid)))
+			(let_exp
+				(semgrep_ellipsis)
+				(scon_exp
+					(integer_scon))))))
+
+=====================================
+Signature Ellipses
+=====================================
+
+signature FOO =
+	sig
+		type t = int
+		...
+	end
+
+---
+
+(source_file
+	(signature_sigdec
+		(sigbind
+			(sigid)
+			(sig_sigexp
+				(type_spec
+					(typbind
+						(tycon)
+						(tycon_ty
+							(longtycon
+								(tycon)))))
+				(semgrep_ellipsis)))))
+
+=====================================
+Structure Ellipses
+=====================================
+
+structure Foo : FOO =
+	struct
+		val x : int = 2	
+		...
+	end
+
+---
+
+(source_file
+	(structure_strdec
+		(strbind
+			(strid)
+			(sigid_sigexp
+				(sigid))
+			(struct_strexp
+				(val_dec
+					(valbind
+						(typed_pat
+							(vid_pat
+								(longvid
+									(vid)))
+							(tycon_ty
+								(longtycon
+									(tycon))))
+						(scon_exp
+							(integer_scon))))
+            (semgrep_ellipsis)))))
+
+=====================================
+Functor Ellipses
+=====================================
+
+functor Foo (X : S) =
+	struct
+		val x : int = 2	
+		...
+	end
+
+---
+
+(source_file
+	(fctbind
+		(fctid)
+		(strid)
+		(sigid_sigexp
+			(sigid))
+		(struct_strexp
+			(val_dec
+				(valbind
+					(typed_pat
+						(vid_pat
+							(longvid
+								(vid)))
+						(tycon_ty
+							(longtycon
+								(tycon))))
+					(scon_exp
+						(integer_scon))))
+			(semgrep_ellipsis))))
+
+=====================================
+Parameter Ellipses
+=====================================
+
+fun f ... = 2
+
+---
+
+(source_file
+	(fun_dec
+		(fvalbind
+			(fmrule
+				(vid)
+				(semgrep_ellipsis)
+				(scon_exp
+					(integer_scon))))))
+
+=====================================
+Match Ellipses
+=====================================
+
+case 2 of
+  3 => NONE
+| ...
+| 4 => SOME 5 
+
+---
+
+(source_file
+	(case_exp
+		(scon_exp
+			(integer_scon))
+		(mrule
+			(scon_pat
+				(integer_scon))
+          (vid_exp
+            (longvid
+              (vid))))
+        (mrule
+          (disj_pat
+            (semgrep_ellipsis)
+            (scon_pat
+              (integer_scon)))
+          (app_exp
+            (vid_exp
+              (longvid
+                (vid)))
+            (scon_exp
+              (integer_scon))))))

--- a/lang/sml/Makefile
+++ b/lang/sml/Makefile
@@ -1,0 +1,1 @@
+../Makefile.common

--- a/lang/sml/extensions.txt
+++ b/lang/sml/extensions.txt
@@ -1,0 +1,10 @@
+# File extensions for the target language, one per line. This is used for
+# collecting parsing stats from the repos specified in 'projects.txt'. e.g.:
+#
+# .h
+# .c
+#
+
+.sml
+.sig
+.fun

--- a/lang/sml/fyi.list
+++ b/lang/sml/fyi.list
@@ -1,0 +1,3 @@
+semgrep-grammars/src/tree-sitter-sml/LICENSE
+semgrep-grammars/src/tree-sitter-sml/grammar.js
+semgrep-grammars/src/semgrep-sml/grammar.js

--- a/lang/sml/projects.txt
+++ b/lang/sml/projects.txt
@@ -1,0 +1,18 @@
+# Git URLs of publicly-accessible projects to be used for parsing stats,
+# one per line.
+#
+https://github.com/standardml/parcom
+https://github.com/shygoo/n64sym
+https://github.com/robsimmons/sml-lib
+https://github.com/SMLFamily/BasisLibrary
+https://github.com/standardml/cmlib
+https://github.com/standardml/twelf
+https://github.com/Quantomatic/quantomatic
+https://github.com/RedPRL/sml-redprl
+https://github.com/urweb/urweb
+
+# This one's for you, Sam.
+https://github.com/shwestrick/smlfmt
+
+# :^)
+https://github.com/brandonspark/mulligan


### PR DESCRIPTION
Yes, I have an agenda.

This is step 1 in integrating Semgrep into my summer class' curriculum, so that I can use Semgrep for pedagogical purposes.

We don't necessarily need to advertise SML as "experimental" once it's in (unless you think it would benefit), I just want it for my own use.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
