### PR TITLE
html: support attribute pattern for semgrep

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-html/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-html/grammar.js
@@ -24,18 +24,37 @@ module.exports = grammar(base_grammar, {
   */
     rules: {
 
-    // XML extensions
-    _node: ($, previous) => choice(
-       $.xmldoctype,
-       previous
+     fragment: $ => repeat($._toplevel_node),
+
+    // like _node, but without $.text and with new entries
+    _toplevel_node: $ => choice(
+      $.doctype,
+      //nope: $.text,
+      $.element,
+      $.script_element,
+      $.style_element,
+      $.erroneous_end_tag,
+      //NEW:
+      $.toplevel_attribute,
+      $.xmldoctype
     ),
-    
+
+    // similar to $.attribute, but with mandatory '='
+    toplevel_attribute: $ => seq(
+        $.attribute_name,
+       '=',
+        choice(
+          $.attribute_value,
+          $.quoted_attribute_value
+        )
+      ),
+
     xmldoctype: $ => seq(
       '<?xml',
       repeat($.attribute),
       '?>'
     ),
-	
+
     //alt: redefine instead _start_tag_name and _end_tag_name?
     start_tag: ($, previous) => choice(
       $.semgrep_start_tag,

--- a/lang/semgrep-grammars/src/semgrep-html/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-html/grammar.js
@@ -24,6 +24,15 @@ module.exports = grammar(base_grammar, {
   */
     rules: {
 
+     // toplevel_node was added to support toplevel attributes patterns. An
+     // alternative would be to just do
+     //    fragment: choice(previous, toplevel_attribute)
+     // but this does not work because 'foo=1' would still be parsed
+     // as a text. Indeed, the regexp for text accepts also newlines and
+     // so the match is probably longer than for toplevel_attribute.
+     // Hence the introduction of an extra _toplevel_node that does not
+     // allow toplevel text. Hopefully most HTML files have some
+     // toplevel elements (e.g., <html>) and not just text.
      fragment: $ => repeat($._toplevel_node),
 
     // like _node, but without $.text and with new entries

--- a/lang/semgrep-grammars/src/semgrep-html/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-html/grammar.js
@@ -24,18 +24,21 @@ module.exports = grammar(base_grammar, {
   */
     rules: {
 
-     // toplevel_node was added to support toplevel attributes patterns. An
+     // toplevel_node was added to support toplevel attribute patterns. An
      // alternative would be to just do
-     //    fragment: choice(previous, toplevel_attribute)
+     //    fragment: choice(previous, $.toplevel_attribute)
      // but this does not work because 'foo=1' would still be parsed
-     // as a text. Indeed, the regexp for text accepts also newlines and
-     // so the match is probably longer than for toplevel_attribute.
+     // as a text. Indeed, the regexp for 'text' accepts also newlines and
+     // so the match is probably longer than for a toplevel_attribute.
      // Hence the introduction of an extra _toplevel_node that does not
      // allow toplevel text. Hopefully most HTML files have some
      // toplevel elements (e.g., <html>) and not just text.
-     fragment: $ => repeat($._toplevel_node),
+     fragment: $ => choice(
+        repeat($._toplevel_node),
+        $.toplevel_attribute,
+    ),
 
-    // like _node, but without $.text and with new entries
+    // like _node, but without $.text and with a new entry for XML
     _toplevel_node: $ => choice(
       $.doctype,
       //nope: $.text,
@@ -44,7 +47,6 @@ module.exports = grammar(base_grammar, {
       $.style_element,
       $.erroneous_end_tag,
       //NEW:
-      $.toplevel_attribute,
       $.xmldoctype
     ),
 

--- a/lang/semgrep-grammars/src/semgrep-html/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-html/test/corpus/semgrep.txt
@@ -90,3 +90,14 @@ XML constructs
               (attribute_value))))
         (end_tag
           (tag_name))))
+
+===================================
+Attribute pattern
+===================================
+foo="true"
+---
+(fragment
+      (toplevel_attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value))))


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/7344

test plan:
test file included
cd lang; ./test-lang html


### Security

- [x] Change has no security implications (otherwise, ping the security team)