### PR TITLE
improve sml, change projects

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-sml/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-sml/grammar.js
@@ -23,6 +23,13 @@ module.exports = grammar(base_grammar, {
     // As it turns out, $x parses as the application of `$` to an identifier.
     // We'll just allow it to parse like that, and then fix it in generic translation.
 
+    _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
+
+    _alphaAlphaNumeric_ident: ($, previous) => choice(
+      $._semgrep_metavariable,
+      previous
+    ),
+
     _dec_no_local: ($, previous) => choice(
       $.semgrep_ellipsis,
       previous

--- a/lang/semgrep-grammars/src/semgrep-sml/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-sml/test/corpus/semgrep.txt
@@ -12,13 +12,9 @@ val x = $X
 			(vid_pat
 				(longvid
 					(vid)))
-			(app_exp
-				(vid_exp
-					(longvid
-						(vid)))
-				(vid_exp
-					(longvid
-						(vid)))))))
+			(vid_exp
+				(longvid
+					(vid))))))
 
 =====================================
 Simple Metavariable Binding
@@ -31,13 +27,9 @@ val $X = 2
 (source_file
 	(val_dec
 		(valbind
-			(app_pat
-				(vid_pat
-					(longvid
-						(vid)))
-				(vid_pat
-					(longvid
-						(vid))))
+			(vid_pat
+				(longvid
+					(vid)))
 			(scon_exp
 				(integer_scon)))))
 

--- a/lang/sml/projects.txt
+++ b/lang/sml/projects.txt
@@ -2,7 +2,6 @@
 # one per line.
 #
 https://github.com/standardml/parcom
-https://github.com/shygoo/n64sym
 https://github.com/robsimmons/sml-lib
 https://github.com/SMLFamily/BasisLibrary
 https://github.com/standardml/cmlib


### PR DESCRIPTION
This PR adds in better metavariables, no longer relying on translating the applications themselves. I couldn't use `token.immediate` though, as it would make it no longer work, over `token`.

One of the projects was bringing our parse rate way down. Don't trust N64-related programs written in SML, I guess: https://github.com/shygoo/n64sym/blob/master/src/builtin_signatures.sig

Our parse rate is now 99.928%. Sorry, I forgot to say earlier what it was.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
