### PR TITLE
chore: fork `tree-sitter-kotlin`, and update tree-sitter kotlin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/tree-sitter/tree-sitter-ruby.git
 [submodule "lang/semgrep-grammars/src/tree-sitter-kotlin"]
 	path = lang/semgrep-grammars/src/tree-sitter-kotlin
-	url = https://github.com/fwcd/tree-sitter-kotlin.git
+	url = https://github.com/brandonspark/tree-sitter-kotlin 
 [submodule "lang/semgrep-grammars/src/tree-sitter-c-sharp"]
 	path = lang/semgrep-grammars/src/tree-sitter-c-sharp
 	url = https://github.com/tree-sitter/tree-sitter-c-sharp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/tree-sitter/tree-sitter-ruby.git
 [submodule "lang/semgrep-grammars/src/tree-sitter-kotlin"]
 	path = lang/semgrep-grammars/src/tree-sitter-kotlin
-	url = https://github.com/brandonspark/tree-sitter-kotlin 
+	url = https://github.com/returntocorp/tree-sitter-kotlin.git 
 [submodule "lang/semgrep-grammars/src/tree-sitter-c-sharp"]
 	path = lang/semgrep-grammars/src/tree-sitter-c-sharp
 	url = https://github.com/tree-sitter/tree-sitter-c-sharp.git

--- a/lang/semgrep-grammars/src/semgrep-kotlin/src/scanner.c
+++ b/lang/semgrep-grammars/src/semgrep-kotlin/src/scanner.c
@@ -213,11 +213,11 @@ bool scan_multiline_comment(TSLexer *lexer) {
         if (after_star) {
           after_star = false;
           nesting_depth--;
-          // if (nesting_depth == 0) {
+          if (nesting_depth == 0) {
             lexer->result_symbol = MULTILINE_COMMENT;
             mark_end(lexer);
             return true;
-          // }
+          }
         } else {
           after_star = false;
           if (lexer->lookahead == '*') {

--- a/lang/semgrep-grammars/src/semgrep-kotlin/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-kotlin/test/corpus/semgrep.txt
@@ -16,10 +16,11 @@ class $CLASS {
     (class_body
       (function_declaration
         (simple_identifier)
-        (parameter
-          (simple_identifier)
-          (user_type
-            (type_identifier)))
+        (function_value_parameters
+          (parameter
+            (simple_identifier)
+            (user_type
+              (type_identifier))))
         (function_body
           (statements
             (call_expression
@@ -68,6 +69,7 @@ class Foo {
     (class_body
       (function_declaration
         (simple_identifier)
+        (function_value_parameters)
         (function_body
           (statements
             (ellipsis)))))))
@@ -91,6 +93,7 @@ class Foo {
     (class_body
       (function_declaration
         (simple_identifier)
+        (function_value_parameters)
         (function_body
           (statements
             (property_declaration
@@ -140,9 +143,10 @@ fun foo(..., bar: String, ...) {}
 
 (source_file
   (function_declaration (simple_identifier)
-     (ellipsis)
-     (parameter (simple_identifier) (user_type (type_identifier)))
-     (ellipsis)
+     (function_value_parameters
+      (ellipsis)
+      (parameter (simple_identifier) (user_type (type_identifier)))
+      (ellipsis))
      (function_body))) 
 
 =====================================
@@ -170,6 +174,7 @@ fun foo() {
 ---
 (source_file
   (function_declaration (simple_identifier)
+    (function_value_parameters)
     (function_body
       (statements
         (call_expression (simple_identifier) (call_suffix (value_arguments)))


### PR DESCRIPTION
There has been a lack of responsiveness from the maintainers of https://github.com/fwcd/tree-sitter-kotlin, and we need to make progress. So let's fork the `tree-sitter-kotlin` repository. We can go back later if we need to.

(I don't know if this is actually the right way to do it)

@aryx @bmahe 

### Security

- [X] Change has no security implications (otherwise, ping the security team)
