### PR TITLE
Add missing symlink for cairo

### DIFF
--- a/lang/semgrep-grammars/lang/cairo
+++ b/lang/semgrep-grammars/lang/cairo
@@ -1,0 +1,1 @@
+../src/semgrep-cairo


### PR DESCRIPTION
This should fix the CI error in
https://github.com/returntocorp/ocaml-tree-sitter-semgrep/pull/409a

Maybe the author didn't use add-simple-lang and created the files
manually, but then he forgot a symlink that is created by
add-simple-lang (actually by sg-add-simple-lang, called by
add-simple-lang)

test plan:
cd cairo
./test-lang cairo

wait for Circle green check in CI


### Security

- [x] Change has no security implications (otherwise, ping the security team)