### PR TITLE
[Cairo 1.0] Improve Semgrep extension grammar

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-cairo/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-cairo/grammar.js
@@ -10,15 +10,12 @@ const standard_grammar = require("tree-sitter-cairo/grammar.js");
 module.exports = grammar(standard_grammar, {
   name: "cairo",
 
+  inline: ($, previous) => [...previous, $.name],
+
   rules: {
     // Entry point
-    source_file: ($, previous) => {
-      return choice(previous, $.semgrep_expression, $.semgrep_statement);
-    },
-
-    _declaration: ($, previous) => {
-      return choice(...previous.members, $.ellipsis);
-    },
+    source_file: ($, previous) =>
+      choice(previous, $.semgrep_expression, $.semgrep_statement),
 
     // Alternate "entry point". Allows parsing a standalone expression.
     semgrep_expression: ($) => seq("__SEMGREP_EXPRESSION", $._expression),
@@ -29,22 +26,33 @@ module.exports = grammar(standard_grammar, {
     // Metavariables
     semgrep_var: ($) => /\$[A-Z_][A-Z_0-9]*/,
 
-    // Expression ellipsis
-    _expression: ($, previous) => {
-      return choice(
-        ...previous.members,
-        $.semgrep_var,
-        $.ellipsis,
-        $.deep_ellipsis
-      );
-    },
-
-    member_declaration: ($, previous) => {
-      return choice(previous, $.ellipsis);
-    },
-
     deep_ellipsis: ($) => seq("<...", $._expression, "...>"),
 
     ellipsis: ($) => "...",
+
+    _declaration: ($, previous) => choice(...previous.members, $.ellipsis),
+
+    // Expression ellipsis
+    _expression: ($, previous) =>
+      choice(...previous.members, $.ellipsis, $.deep_ellipsis),
+
+    _simple_expression: ($, previous) =>
+      choice(...previous.members, $.ellipsis, $.deep_ellipsis),
+
+    _statement: ($, previous) =>
+      choice(...previous.members, $.ellipsis, $.deep_ellipsis),
+
+    name: ($, previous) => choice(alias(previous, $.name), $.semgrep_var),
+
+    attribute_argument: ($, previous) => choice(...previous.members, $.ellipsis),
+
+    selector_expression: ($, previous) => choice(
+      previous, 
+      seq(field("value", $._expression), ".", $.ellipsis)
+    ),
+
+    parameter_declaration: ($, previous) => choice(previous, $.ellipsis),
+
+    member_declaration: ($, previous) => choice(previous, $.ellipsis),
   },
 });

--- a/lang/semgrep-grammars/src/semgrep-cairo/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-cairo/test/corpus/semgrep.txt
@@ -1,0 +1,101 @@
+===================
+Semgrep Constructs
+===================
+
+#[derive(..., Unsafe, ...)]
+struct foo;
+
+fn $FOO() {}
+fn foo(..., x: usize, ...) {}
+fn foo(...) {}
+
+fn foo() {
+    let $X = 42;
+
+    if $X < $Y {}
+    if <... $X == true ...> {}
+
+    ...;
+    let $X = $Y;
+    ...;
+}
+
+---
+
+(source_file
+    (struct_declaration
+        (attribute_list
+            (attribute 
+                (path (name))
+                (attribute_argument (ellipsis))
+                (attribute_argument (name))
+                (attribute_argument (ellipsis))
+            )
+        )
+        (name)
+    )
+    (function_declaration 
+        (function_signature
+            (semgrep_var)
+            (parameter_list)
+        )
+        (block)
+    )
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list
+                (parameter_declaration (ellipsis))
+                (parameter_declaration 
+                    (name) 
+                    (type_identifier (qualified_name (name)))
+                )
+                (parameter_declaration (ellipsis))
+            )
+        )
+        (block)
+    )
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list
+                (parameter_declaration (ellipsis))
+            )
+        )
+        (block)
+    )
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list)
+        )
+        (block
+            (let_statement
+                (identifier)
+                (number (integer))
+            )
+            (if_expression
+                (binary_expression
+                    (qualified_name (semgrep_var))
+                    (qualified_name (semgrep_var))
+                )
+                (block)
+            )
+            (if_expression
+                (deep_ellipsis
+                    (binary_expression
+                        (qualified_name (semgrep_var))
+                        (true)
+                    )
+                )
+                (block)
+            )
+            (ellipsis)
+            (let_statement
+                (identifier)
+                (qualified_name (semgrep_var))
+            )
+            (ellipsis)
+        )
+    )
+)

--- a/lang/semgrep-grammars/src/semgrep-cairo/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-cairo/test/corpus/semgrep.txt
@@ -1,24 +1,12 @@
 ===================
-Semgrep Constructs
+Ellipsis in attribute
 ===================
 
 #[derive(..., Unsafe, ...)]
-struct foo;
+struct Foo;
 
-fn $FOO() {}
-fn foo(..., x: usize, ...) {}
-fn foo(...) {}
-
-fn foo() {
-    let $X = 42;
-
-    if $X < $Y {}
-    if <... $X == true ...> {}
-
-    ...;
-    let $X = $Y;
-    ...;
-}
+#[derive(...)]
+trait Foo {}
 
 ---
 
@@ -34,13 +22,28 @@ fn foo() {
         )
         (name)
     )
-    (function_declaration 
-        (function_signature
-            (semgrep_var)
-            (parameter_list)
+    (trait_declaration
+        (attribute_list
+            (attribute 
+                (path (name))
+                (attribute_argument (ellipsis))
+            )
         )
-        (block)
+        (name)
+        (trait_body)
     )
+)
+
+======================================
+Ellipsis in function parameters
+======================================
+
+fn foo(..., x: usize, ...) {}
+fn foo(...) {}
+
+---
+
+(source_file
     (function_declaration 
         (function_signature
             (name)
@@ -64,12 +67,175 @@ fn foo() {
         )
         (block)
     )
+)
+
+======================================
+Ellipsis in body
+======================================
+
+fn foo() {
+    ...
+}
+
+fn foo() {
+    ...;
+    let x = 42;
+    ...;
+}
+
+---
+
+(source_file
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list)
+        )
+        (block (ellipsis))
+    )
     (function_declaration 
         (function_signature
             (name)
             (parameter_list)
         )
         (block
+            (ellipsis)
+            (let_statement (identifier) (number (integer)))
+            (ellipsis)
+        )
+    )
+)
+
+======================================
+Ellipsis in call arguments
+======================================
+
+fn foo() {
+    bar(..., 42, ...)
+}
+
+---
+
+(source_file
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list)
+        )
+        (block 
+            (call_expression
+                (qualified_name (name))
+                (argument_list
+                    (ellipsis)
+                    (number (integer))
+                    (ellipsis)
+                )
+            )
+        )
+    )
+)
+
+======================================
+Ellipsis in selector expression
+======================================
+
+fn foo() {
+    foo1. ... .foo2;
+}
+
+---
+
+(source_file
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list)
+        )
+        (block 
+            (selector_expression
+                (selector_expression
+                    (qualified_name (name))
+                    (ellipsis)
+                )
+                (name)
+            )
+        )
+    )
+)
+
+======================================
+Deep ellipsis in if
+======================================
+
+fn foo() {
+    if <... a == true ...> {}
+}
+
+---
+
+(source_file
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list)
+        )
+        (block 
+            (if_expression
+                (deep_ellipsis
+                    (binary_expression
+                        (qualified_name (name))
+                        (true)
+                    )
+                )
+                (block)
+            )
+        )
+    )
+)
+
+======================================
+Metavariable in let
+======================================
+
+fn foo() {
+    let $X = $Y;
+}
+
+---
+
+(source_file
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list)
+        )
+        (block 
+            (let_statement
+                (identifier)
+                (qualified_name (semgrep_var))
+            )
+        )
+    )
+)
+
+======================================
+Metavariable in expression
+======================================
+
+fn foo() {
+    let $X = 42;
+    if $X < $Y {}
+}
+
+---
+
+(source_file
+    (function_declaration 
+        (function_signature
+            (name)
+            (parameter_list)
+        )
+        (block 
             (let_statement
                 (identifier)
                 (number (integer))
@@ -81,21 +247,24 @@ fn foo() {
                 )
                 (block)
             )
-            (if_expression
-                (deep_ellipsis
-                    (binary_expression
-                        (qualified_name (semgrep_var))
-                        (true)
-                    )
-                )
-                (block)
-            )
-            (ellipsis)
-            (let_statement
-                (identifier)
-                (qualified_name (semgrep_var))
-            )
-            (ellipsis)
         )
+    )
+)
+
+======================================
+Metavariable in function name
+======================================
+
+fn $FUN() {}
+
+---
+
+(source_file
+    (function_declaration 
+        (function_signature
+            (semgrep_var)
+            (parameter_list)
+        )
+        (block )
     )
 )


### PR DESCRIPTION
### Context

The current grammar does not support some simple construct like `let $X = 42;` due to the fact that the metavariable is in the wrong production. Additionally, they were minor issues in the original tree-sitter grammar that prevented some semgrep construct to be properly interpreted.

This PR fix these issues and allow richer Semgrep patterns to be used on Cairo 1.0

### Security

- [x] Change has no security implications (otherwise, ping the security team)
