### PR TITLE
swift: Support ellipsis in navigation suffix

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-swift/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-swift/grammar.js
@@ -64,13 +64,21 @@ module.exports = grammar(base_grammar, {
     ),
 
     _type_level_declaration: ($, previous) => choice (
-      previous, 
+      previous,
       $.semgrep_ellipsis,
     ),
 
     type_parameter: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,
+    ),
+
+    navigation_suffix: ($, previous) => choice(
+      previous,
+      seq(
+        $._dot,
+        field("suffix", $.semgrep_ellipsis),
+      ),
     ),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
@@ -170,3 +170,30 @@ foo
 (source_file
   (simple_identifier)
   (fully_open_range))
+
+================================================================================
+Field Access with Ellipsis
+================================================================================
+
+$FOO. ... .bar(startNum..<endData.count)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (call_expression
+    (navigation_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (semgrep_ellipsis)))
+      (navigation_suffix
+        (simple_identifier)))
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (range_expression
+            (simple_identifier)
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier)))))))))


### PR DESCRIPTION
returntocorp/semgrep#7664

### Security

- [x] Change has no security implications (otherwise, ping the security team)
