### PR TITLE
fix! make C# builds work in CI

### DIFF
--- a/lang/Makefile
+++ b/lang/Makefile
@@ -16,6 +16,7 @@ SUPPORTED_TS_LANGUAGES = \
   cairo \
   clojure \
   cpp \
+	c-sharp \
   dart \
   dockerfile \
   elixir \
@@ -42,7 +43,7 @@ SUPPORTED_TS_LANGUAGES = \
   typescript \
   vue
 # Commented out due to hitting memory limits in CI:
-#  hack c-sharp
+#  hack 
 
 
 # List of all language variants, as they're made available to semgrep.
@@ -61,6 +62,7 @@ SUPPORTED_DIALECTS = \
   c \
   clojure \
   cpp \
+	c-sharp \
   dart \
   dockerfile \
   elixir \
@@ -86,7 +88,7 @@ SUPPORTED_DIALECTS = \
   tsx \
   typescript \
   vue
-#  hack c-sharp
+#  hack
 
 
 # Languages which are set up to run parsing stats. Ideally, this is all
@@ -99,6 +101,7 @@ STAT_LANGUAGES1 = \
   c \
   cairo \
   cpp \
+	c-sharp \
   dockerfile \
   elixir \
   go \
@@ -109,7 +112,7 @@ STAT_LANGUAGES1 = \
   julia \
   kotlin
 # Commented out due to hitting memory limits in CI:
-#  hack c-sharp
+#  hack 
 
 STAT_LANGUAGES2 = \
   apex \

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -86,6 +86,10 @@ module.exports = grammar(standard_grammar, {
         previous,
         prec.right(100, seq($.ellipsis, ';')),  // expression ellipsis
         prec.right(100, $.ellipsis),  // statement ellipsis
+        seq($.deep_ellipsis, ';'),
+        seq($.member_access_ellipsis_expression, ';'),
+        seq($._semgrep_metavariable, ';'),
+        seq($.typed_metavariable, ';')
       );
     },
 

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -1,6 +1,6 @@
-=====================================
+================================================================================
 Metavariables
-=====================================
+================================================================================
 
 class $CLASS {
   void $FUNC($TYPE $PARAM) {
@@ -8,7 +8,7 @@ class $CLASS {
   }
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (class_declaration
@@ -17,7 +17,10 @@ class $CLASS {
       (method_declaration
         (predefined_type)
         (identifier)
-        (parameter_list (parameter (identifier) (identifier)))
+        (parameter_list
+          (parameter
+            (identifier)
+            (identifier)))
         (block
           (local_declaration_statement
             (variable_declaration
@@ -30,9 +33,9 @@ class $CLASS {
                     (identifier)
                     (identifier)))))))))))
 
-=====================================
+================================================================================
 Ellipsis for expression
-=====================================
+================================================================================
 
 class Foo {
   void Bar() {
@@ -42,7 +45,7 @@ class Foo {
   }
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (class_declaration
@@ -55,23 +58,20 @@ class Foo {
         (block
           (expression_statement
             (assignment_expression
-              (identifier) (assignment_operator) (integer_literal))
-          )
-          (expression_statement (ellipsis))
+              (identifier)
+              (assignment_operator)
+              (integer_literal)))
+          (expression_statement
+            (ellipsis))
           (expression_statement
             (assignment_expression
-              (identifier) (assignment_operator) (integer_literal)
-            )
-          )
-        )
-      )
-    )
-  )
-)
+              (identifier)
+              (assignment_operator)
+              (integer_literal))))))))
 
-=====================================
+================================================================================
 Ellipsis for statements
-=====================================
+================================================================================
 
 class Foo {
   void Bar() {
@@ -81,7 +81,7 @@ class Foo {
   }
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (class_declaration
@@ -96,26 +96,18 @@ class Foo {
             (assignment_expression
               (identifier)
               (assignment_operator)
-              (integer_literal)
-            )
-          )
-          (expression_statement (ellipsis))
+              (integer_literal)))
+          (expression_statement
+            (ellipsis))
           (expression_statement
             (assignment_expression
               (identifier)
               (assignment_operator)
-              (integer_literal)
-            )
-          )
-        )
-      )
-    )
-  )
-)
+              (integer_literal))))))))
 
-=====================================
+================================================================================
 Deep expression ellipsis
-=====================================
+================================================================================
 
 class Foo {
   void Bar() {
@@ -123,7 +115,7 @@ class Foo {
   }
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (class_declaration
@@ -138,70 +130,65 @@ class Foo {
             (assignment_expression
               (identifier)
               (assignment_operator)
-              (deep_ellipsis (integer_literal))
-            )
-          )
-        )
-      )
-    )
-  )
-)
+              (deep_ellipsis
+                (integer_literal)))))))))
 
-=====================================
+================================================================================
 Toplevel expression
-=====================================
+================================================================================
 
 __SEMGREP_EXPRESSION
 42
 
----
+--------------------------------------------------------------------------------
 
-(compilation_unit (semgrep_expression (integer_literal)))
+(compilation_unit
+  (semgrep_expression
+    (integer_literal)))
 
-=====================================
+================================================================================
 Ellipsis for enums
-=====================================
+================================================================================
 
 public enum $ENUM { ... }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-      (enum_declaration
-        (modifier)
-        (identifier)
-        (enum_member_declaration_list
-          (enum_member_declaration
-            (ellipsis)))))
+  (enum_declaration
+    (modifier)
+    (identifier)
+    (enum_member_declaration_list
+      (enum_member_declaration
+        (ellipsis)))))
 
-=====================================
+================================================================================
 Argument ellipsis
-=====================================
+================================================================================
 
 __SEMGREP_EXPRESSION
 foo(...)
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (semgrep_expression
     (invocation_expression
       (identifier)
-      (argument_list (argument (ellipsis)))
-    )
-  )
-)
+      (argument_list
+        (argument
+          (ellipsis))))))
 
-=====================================
+================================================================================
 Parameter ellipsis in method definition
-=====================================
+================================================================================
 
 class A {
   public void SomeMethod(..., string p, ...) {
   }
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (class_declaration
@@ -221,15 +208,15 @@ class A {
             (ellipsis)))
         (block)))))
 
-=====================================
+================================================================================
 Ellipsis in class declaration
-=====================================
+================================================================================
 
 class A {
   ...
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (class_declaration
@@ -237,53 +224,56 @@ class A {
     (declaration_list
       (ellipsis))))
 
-=====================================
+================================================================================
 Ellipsis in method chain
-=====================================
+================================================================================
 $X = $O.foo(). ... .bar();
 
----
+--------------------------------------------------------------------------------
+
 (compilation_unit
   (global_statement
-   (expression_statement
-     (assignment_expression
-       (identifier)
-       (assignment_operator)
-       (invocation_expression
-         (member_access_expression
-           (member_access_ellipsis_expression
+    (expression_statement
+      (assignment_expression
+        (identifier)
+        (assignment_operator)
+        (invocation_expression
+          (member_access_expression
+            (member_access_ellipsis_expression
               (invocation_expression
-                (member_access_expression (identifier) (identifier))
-               (argument_list))
+                (member_access_expression
+                  (identifier)
+                  (identifier))
+                (argument_list))
               (ellipsis))
-          (identifier))
-         (argument_list))))))
+            (identifier))
+          (argument_list))))))
 
-=====================================
+================================================================================
 Typed metavariable
-=====================================
+================================================================================
 
 __SEMGREP_EXPRESSION
 (FooClass $FOO).method()
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-   (semgrep_expression
-      (invocation_expression
-         (member_access_expression
-	    (typed_metavariable (identifier))
-	    (identifier))
-	 (argument_list)))) 
+  (semgrep_expression
+    (invocation_expression
+      (member_access_expression
+        (typed_metavariable
+          (identifier))
+        (identifier))
+      (argument_list))))
 
-
-==========================
+================================================================================
 Ellipses + metavariables as args
-==========================
+================================================================================
 
 foo($...ARGS, 3, $...ARGS);
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (global_statement
@@ -297,3 +287,58 @@ foo($...ARGS, 3, $...ARGS);
             (integer_literal))
           (argument
             (semgrep_variadic_metavariable)))))))
+
+================================================================================
+Metavariable expression statement
+================================================================================
+
+$X;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement)))
+
+================================================================================
+Typed metavariable expression statement
+================================================================================
+
+(int $X);
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (typed_metavariable
+        (predefined_type)))))
+
+================================================================================
+Deep ellipsis expression statement
+================================================================================
+
+<... foo ...>;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (deep_ellipsis
+        (identifier)))))
+
+================================================================================
+Deep ellipsis expression statement
+================================================================================
+
+foo->...;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (member_access_ellipsis_expression
+        (identifier)
+        (ellipsis)))))


### PR DESCRIPTION
This PR updates C# again, but incorporates the changes I made in https://github.com/tree-sitter/tree-sitter-c-sharp/pull/309 that will hopefully make builds work again.

While I'm here, I also fixed Semgrep constructs which should be usable as standalone expression statements. This is because in C#, expression statements used to just be an expression and semicolon, but they made it more restrictive, by restricting the kinds of expressions that can appear. That means things like
```
$X;
```
no longer parse. So we had to add those in.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
