### PR TITLE
Solidity: add metavariables for versions

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
@@ -32,8 +32,21 @@ module.exports = grammar(base_grammar, {
           );
         },
 
-      // Metavariables. No need to patch the identifier rule because
-      // Solidity already accepts '$' as part of an identifier
+        // Metavariables. No need to patch the identifier rule because
+        // Solidity already accepts '$' as part of an identifier
+
+        // Metavariables for Solidity versions
+        _pragma_version_constraint: ($, previous) => {
+            return choice(
+                previous,
+                seq(
+                    optional(
+                        $.solidity_version_comparison_operator
+                    ),
+                    $.identifier
+                ),
+            )
+        },
       
       // Ellipsis
         _expression: ($, previous) => {

--- a/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
@@ -1,6 +1,26 @@
 =====================================
-Metavariables
+Metavariable for version
 =====================================
+pragma solidity ^ $VER;
+---
+(source_file
+  (pragma_directive
+    (solidity_pragma_token
+      (solidity_version_comparison_operator)
+      (identifier))))
+
+=====================================
+Metavariable for versions range
+=====================================
+pragma solidity >= $VER_FROM <= $VER_TO;
+---
+(source_file
+  (pragma_directive
+    (solidity_pragma_token
+      (solidity_version_comparison_operator)
+      (identifier)
+      (solidity_version_comparison_operator)
+      (identifier))))
 
 =====================================
 Ellipsis for contract


### PR DESCRIPTION
### Description

Now it is not possible to find specific Solidity versions in the code using metavariables. However, sometimes it is necessary to define a version or range of supported Solidity versions to check for some security rules (for example, checking for overflow/underflow, for version-specific bugs - [link](https://blog.soliditylang.org/category/security-alerts/), simple outdated versions checks). 

With this update it should be possible to match the version:

```yaml
- pattern: pragma solidity >= $VER;
```

### Security

- [x] Change has no security implications (otherwise, ping the security team)
