### PR TITLE
fix: c# top level ellipses

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -75,6 +75,29 @@ module.exports = grammar(standard_grammar, {
       );
     },
 
+    // We want ellipses to be interchangeable with namespace member declarations, so
+    // we need to add them in to `type_declaration` here. 
+    _type_declaration: ($, previous) => { 
+      return choice(
+        ...previous.members,
+        $.ellipsis
+      )
+    },
+
+    // We do this because a file scoped namespace declaration is a top-level 
+    // thing, but ellipses are more particular. We want ellipses to be used 
+    // in conjunction with file scoped namespace declarations.
+    // Unfortunately, in the base grammar, we can either have ellipsis 
+    // statements, or a file scoped declaration! That's no good. To play 
+    // around the previous grammar, we simply allow what came before to also 
+    // occur before a file scoped namespace declaration.
+    file_scoped_namespace_declaration: ($, previous) => {
+      return seq(
+        seq(repeat($.global_statement), repeat($._namespace_member_declaration)),
+        previous,
+      )
+    },
+
     enum_member_declaration: ($, previous) => choice(
           previous,
 	  $.ellipsis,

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -342,3 +342,40 @@ foo->...;
       (member_access_ellipsis_expression
         (identifier)
         (ellipsis)))))
+
+================================================================================
+Namespace declarations and ellipses
+================================================================================
+
+...
+namespace $N { };
+...
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (ellipsis)))
+  (namespace_declaration
+    (identifier)
+    (declaration_list))
+  (ellipsis))
+
+================================================================================
+File scoped namespace declarations and ellipses
+================================================================================
+
+...
+namespace $N;
+...
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (file_scoped_namespace_declaration
+    (global_statement
+      (expression_statement
+        (ellipsis)))
+    (identifier)
+    (ellipsis)))


### PR DESCRIPTION
The C# grammar is too restrictive when it comes to top-level compilation units. It expects certain top-level constructs in a given order, and does not allow intermingling. This is too restrictive, particularly in the case of ellipses, because we expect that only global statements are ellipses.

This PR allows ellipses to occur at the top-level in a few more cases, particular around namespace declarations.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
