### PR TITLE
Adding support for metavariables for python to move towards parsing patterns via tree-sitter 

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-python/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-python/grammar.js
@@ -27,7 +27,13 @@ module.exports = grammar(base_grammar, {
   */
     // Metavariables
 
-    
+   // Rather than creating a separate metavariable term 
+   // and adding it to identifiers, this instead overrides the
+   // regex that is defined in the original tree-sitter grammar. 
+   // this is needed since currently in the original tree-sitter grammar, 
+   // identifier is a terminal, and thus can't do
+   // the usual choice/previous shadowing definition.
+
     identifier: $ => /\$?[_\p{XID_Start}][_\p{XID_Continue}]*/,
       
   }

--- a/lang/semgrep-grammars/src/semgrep-python/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-python/grammar.js
@@ -25,5 +25,15 @@ module.exports = grammar(base_grammar, {
       ...previous.members
     ),
   */
+    // Metavariables
+    identifier: ($, previous) => {
+      return choice(
+        previous,
+        $._semgrep_metavariable
+      );
+    },
+
+    _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/)
+      
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-python/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-python/grammar.js
@@ -26,14 +26,9 @@ module.exports = grammar(base_grammar, {
     ),
   */
     // Metavariables
-    identifier: ($, previous) => {
-      return choice(
-        previous,
-        $._semgrep_metavariable
-      );
-    },
 
-    _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/)
+    
+    identifier: $ => /\$?[_\p{XID_Start}][_\p{XID_Continue}]*/,
       
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-python/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-python/test/corpus/semgrep.txt
@@ -1,0 +1,22 @@
+====================================
+Metavariable in match
+====================================
+
+ match $X:
+        case str():
+          print("oh no")
+---
+ (module
+      (match_statement
+        (identifier)
+        (case_clause
+          (case_pattern
+            (call
+              (identifier)
+              (argument_list)))
+          (block
+            (expression_statement
+              (call
+                (identifier)
+                (argument_list
+                  (string))))))))


### PR DESCRIPTION
As per description, this adds support for parsing metavariables as well to move towards parsing more python in tree sitter rather than menhir. Rather than creating a separate metavariable term and adding it to identifiers, this instead overrides the regex that is defined in the original tree-sitter grammar, this is needed since currently in the original tree-sitter grammar, identifier is a terminal, and thus can't do the usual choice/previous shadowing definition. 
### Security

- [x] Change has no security implications (otherwise, ping the security team)
