### PR TITLE
feat(julia): catch ellipsis

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-julia/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-julia/grammar.js
@@ -20,6 +20,13 @@ module.exports = grammar(base_grammar, {
   rules: {
     semgrep_ellipsis: $ => '...',
 
+    catch_clause: $ => prec(1, seq(
+      'catch',
+      optional(choice($.identifier, alias($.semgrep_ellipsis, $.catch_ellipsis))),
+      optional($._terminator),
+      optional($._block),
+    )),
+
     _expression: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,

--- a/lang/semgrep-grammars/src/semgrep-julia/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-julia/test/corpus/semgrep.txt
@@ -19,14 +19,14 @@ bar()
 
 --------------------------------------------------------------------------------
 
-  (source_file
-    (call_expression
-      (identifier)
-      (argument_list))
-    (semgrep_ellipsis)
-    (call_expression
-      (identifier)
-      (argument_list)))
+(source_file
+  (call_expression
+    (identifier)
+    (argument_list))
+  (semgrep_ellipsis)
+  (call_expression
+    (identifier)
+    (argument_list)))
 
 ================================================================================
 Top level public constructor
@@ -48,7 +48,7 @@ end
       (integer_literal))))
 
 ================================================================================
-Abstract type metavariable 
+Abstract type metavariable
 ================================================================================
 
 abstract type $TY end
@@ -133,3 +133,46 @@ end
     (return_statement
       (interpolation_expression
         (identifier)))))
+
+================================================================================
+Catch ellipsis
+================================================================================
+
+try 
+  x = 3
+catch ... 
+  ...
+end
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (try_statement
+    (assignment
+      (identifier)
+      (operator)
+      (integer_literal))
+    (catch_clause
+      (catch_ellipsis)
+      (semgrep_ellipsis))))
+
+================================================================================
+Empty catch followed by ellipsis
+================================================================================
+
+try 
+  x = 3
+catch
+  ...
+end
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (try_statement
+    (assignment
+      (identifier)
+      (operator)
+      (integer_literal))
+    (catch_clause
+      (semgrep_ellipsis))))


### PR DESCRIPTION
This PR just allows `catch` statements which are catching on an ellipsis, which should match both the explicit and implicit catch cases 

### Security

- [X] Change has no security implications (otherwise, ping the security team)
