### PR TITLE
feat(rust): add ellipsis to rust attribute arguments

### DIFF
--- a/lang/rust/test/ok/attribute_ellipsis.rs
+++ b/lang/rust/test/ok/attribute_ellipsis.rs
@@ -1,6 +1,0 @@
-#[test]
-#[get(...)]
-#[attr(..., $FOO, ...)]
-fn main() {
-    println!("Hello World!");
-}

--- a/lang/rust/test/ok/attribute_ellipsis.rs
+++ b/lang/rust/test/ok/attribute_ellipsis.rs
@@ -1,0 +1,6 @@
+#[test]
+#[get(...)]
+#[attr(..., $FOO, ...)]
+fn main() {
+    println!("Hello World!");
+}

--- a/lang/semgrep-grammars/src/semgrep-rust/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-rust/grammar.js
@@ -84,6 +84,17 @@ module.exports = grammar(standard_grammar, {
       ')'
     ),
 
+    meta_arguments: ($, previous) => seq(
+      '(',
+      sepBy(',', choice(
+	$.ellipsis,
+	$.meta_item,
+        $._literal
+      )),
+      optional(','),
+      ')'
+    ),
+
     // TODO: have to use 13 instead of PREC.field because the Rust grammar
     // doesn't export precedences. Should we use something like
     // https://github.com/jhnns/rewire to access this directly?
@@ -100,3 +111,12 @@ module.exports = grammar(standard_grammar, {
     ellipsis: $ => '...',
   }
 });
+
+
+function sepBy1(sep, rule) {
+  return seq(rule, repeat(seq(sep, rule)))
+}
+
+function sepBy(sep, rule) {
+  return optional(sepBy1(sep, rule))
+}

--- a/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
@@ -205,6 +205,39 @@ let $L = $X.iter(). ... .count();
         (field_identifier))
       (arguments))))
 
+
+================================================================================
+Ellipsis for attribute arguments
+================================================================================
+
+#[foo(...)]
+#[foo(bar, ...)]
+#[foo(..., baz, ...)]
+
+--------------------------------------------------------------------------------
+
+(source_file
+      (attribute_item
+        (meta_item
+          (identifier)
+          (meta_arguments
+            (ellipsis))))
+      (attribute_item
+        (meta_item
+          (identifier)
+          (meta_arguments
+            (meta_item
+              (identifier))
+            (ellipsis))))
+      (attribute_item
+        (meta_item
+          (identifier)
+          (meta_arguments
+            (ellipsis)
+            (meta_item
+              (identifier))
+            (ellipsis)))))
+
 ================================================================================
 Toplevel expression
 ================================================================================


### PR DESCRIPTION
### What
This PR adds ellipsis to the allowed arguments of attributes in the rust tree sitter.

### Related Issues
[PA-2903](https://linear.app/semgrep/issue/PA-2903)

### Security

- [x] Change has no security implications (otherwise, ping the security team)
