### PR TITLE
feat(promql): bump to latest parser

### DIFF
--- a/lang/Makefile
+++ b/lang/Makefile
@@ -125,6 +125,7 @@ STAT_LANGUAGES2 = \
   lua \
   ocaml \
   php \
+  promql \
   python \
   r \
   ruby \

--- a/lang/promql/projects.txt
+++ b/lang/promql/projects.txt
@@ -1,1 +1,1 @@
-https://github.com/MichaHoffmann/semgrep-promql-mock-stats
+https://github.com/MichaHoffmann/tree-sitter-promql

--- a/lang/semgrep-grammars/src/semgrep-promql/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-promql/grammar.js
@@ -26,12 +26,16 @@ module.exports = grammar(base_grammar, {
     _duration: ($, prev) => choice($._semgrep_metavariable, prev),
 
     // Ellipsis
+    /*
+     TODO: this is getting unwieldly, find a better way to handle the ellipsis
+    */
+
     label_selectors: ($, _) =>
       seq("{", commaSep(choice($.semgrep_ellipsis, $.label_matcher)), "}"),
 
     grouping: ($) =>
       seq(
-        choice("by", "without"),
+        choice(caseInsensitive("by"), caseInsensitive("without")),
         "(",
         commaSep(choice($.semgrep_ellipsis, $.label_name)),
         ")",
@@ -45,9 +49,22 @@ module.exports = grammar(base_grammar, {
         [6, choice("^")],
         [5, choice("*", "/", "%")],
         [4, choice("+", "-")],
-        [3, seq(choice("==", "!=", ">", ">=", "<", "<="), optional("bool"))],
-        [2, choice("and", "or", "unless")],
-        [1, choice("atan2")],
+        [
+          3,
+          seq(
+            choice("==", "!=", ">", ">=", "<", "<="),
+            optional(caseInsensitive("bool")),
+          ),
+        ],
+        [
+          2,
+          choice(
+            caseInsensitive("and"),
+            caseInsensitive("or"),
+            caseInsensitive("unless"),
+          ),
+        ],
+        [1, choice(caseInsensitive("atan2"))],
       ];
 
       return choice(
@@ -73,4 +90,15 @@ function commaSep(rule) {
 
 function commaSep1(rule) {
   return seq(rule, repeat(seq(",", rule)), optional(","));
+}
+
+// taken from https://github.com/stadelmanma/tree-sitter-fortran/blob/a9c79b20a84075467d705ebe714c90f275dd5835/grammar.js#L1125C1-L1133C2
+function caseInsensitive(keyword) {
+  let result = new RegExp(
+    keyword
+      .split("")
+      .map((l) => (l !== l.toUpperCase() ? `[${l}${l.toUpperCase()}]` : l))
+      .join(""),
+  );
+  return result;
 }

--- a/lang/semgrep-grammars/src/semgrep-promql/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-promql/test/corpus/semgrep.txt
@@ -142,3 +142,16 @@ ellipsis - binary expression both sides
   (binary_expression
     (semgrep_ellipsis)
     (semgrep_ellipsis)))
+
+================================================================================
+ellipsis - empty series matcher
+================================================================================
+
+{...}
+
+--------------------------------------------------------------------------------
+
+(query
+  (instant_vector_selector
+    (label_selectors
+      (semgrep_ellipsis))))


### PR DESCRIPTION
I'll think about a better way to handle the ellipsis for the next PR.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
