### PR TITLE
feat(julia): allow idents as metavariables

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-julia/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-julia/grammar.js
@@ -31,7 +31,7 @@ module.exports = grammar(base_grammar, {
     // We allow an identifier to be a simple metavariable regex, so that
     // we properly support metavariables.
     // Low precedence, so that we take less priority than parsing as
-    // an interpolation expression. See the comments below.
+    // an interpolation expression, if possible. See the comments below.
     identifier: ($, previous) =>
       prec(1, choice(
         previous,
@@ -57,7 +57,7 @@ module.exports = grammar(base_grammar, {
     interpolation_expression: ($, previous) => choice(
       previous,
       // We alias the included metavariable to an $.identifier so that the parse
-      // tree stays the same.
+      // tree stays the same. Otherwise, we will fail `tree-sitter` tests.
       alias(prec(999, /\$[A-Z][a-zA-Z0-9]*/), $.identifier)
     ),
 

--- a/lang/semgrep-grammars/src/semgrep-julia/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-julia/grammar.js
@@ -27,6 +27,40 @@ module.exports = grammar(base_grammar, {
       optional($._block),
     )),
 
+    // Metavariables
+    // We allow an identifier to be a simple metavariable regex, so that
+    // we properly support metavariables.
+    // Low precedence, so that we take less priority than parsing as
+    // an interpolation expression. See the comments below.
+    identifier: ($, previous) =>
+      prec(1, choice(
+        previous,
+        /\$[A-Z][a-zA-Z0-9]*/,
+      )),
+
+    // ...But we also allow an interpolation expression to be a metavariable.
+    // `interpolation_expression` is a superset of identifiers, so this doesn't
+    // produce any extra parsing power, but we play with the precedence so that
+    // anytime we see an interpolation_expression that is a metavariable, we
+    // should prefer to parse it as an `interpolation_expression` rather than an
+    // `identifier`.
+    //
+    // This ensures that in the produced parse tree, even if we are parsing a
+    // Julia target rather than pattern, we can retain enough information to
+    // parse interpolation expressions normally, and only opt-in to parsing them
+    // as identifiers.
+    //
+    // Notably, we can't say that `interpolation_expression` should just be
+    // `prec(999, previous)`, because the token stream is different. We should
+    // be able to handle the same token lexed by the metavariable regex, so we
+    // duplicate the regex here.
+    interpolation_expression: ($, previous) => choice(
+      previous,
+      // We alias the included metavariable to an $.identifier so that the parse
+      // tree stays the same.
+      alias(prec(999, /\$[A-Z][a-zA-Z0-9]*/), $.identifier)
+    ),
+
     _expression: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,

--- a/lang/semgrep-grammars/src/semgrep-julia/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-julia/test/corpus/semgrep.txt
@@ -32,7 +32,7 @@ bar()
 Top level public constructor
 ================================================================================
 
-function f(...) 
+function f(...)
   return 1
 end
 
@@ -64,7 +64,7 @@ abstract type $TY end
 Struct metavariable
 ================================================================================
 
-struct $FOO 
+struct $FOO
   a
   b
 end
@@ -97,7 +97,7 @@ foo(..., 5)
 Ellipsis in if
 ================================================================================
 
-if (...) 
+if (...)
   ...
 end
 
@@ -138,9 +138,9 @@ end
 Catch ellipsis
 ================================================================================
 
-try 
+try
   x = 3
-catch ... 
+catch ...
   ...
 end
 
@@ -160,7 +160,7 @@ end
 Empty catch followed by ellipsis
 ================================================================================
 
-try 
+try
   x = 3
 catch
   ...
@@ -176,3 +176,49 @@ end
       (integer_literal))
     (catch_clause
       (semgrep_ellipsis))))
+
+================================================================================
+Metavariable in import
+================================================================================
+
+using $MODULE: $X
+using $MODULE: $X as $Y
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (import_statement
+    (selected_import
+      (interpolation_expression
+        (identifier))
+      (interpolation_expression
+        (identifier))))
+  (import_statement
+    (selected_import
+      (interpolation_expression
+        (identifier))
+      (import_alias
+        (interpolation_expression
+          (identifier))
+        (identifier)))))
+
+================================================================================
+Metavariable in do block
+================================================================================
+
+map([]) do $X
+    return x
+end
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (call_expression
+    (identifier)
+    (argument_list
+      (vector_expression))
+    (do_clause
+      (parameter_list
+        (identifier))
+      (return_statement
+        (identifier)))))


### PR DESCRIPTION
## What:
This PR hacks the Julia grammar so we can now parse metavariables anywhere an identifier used to appear.

## Why:
This will help write more Julia rules, and more predictably.

## How:
For review, a Julia interpolation expression looks like something like `$x` or `$X`, which notably can resemble a Semgrep metavariable.

Our Semgrep support for Julia was hacked in a way where we just piggyback off of existing parsing ability for `interpolation_expression`, and changing it to a metavariable whenever it looks like a metavariable, during pattern parsing. This is a hack, though, because interpolation expressions can appear in a lot of places, but they cannot appear _everywhere_ an identifier can.

In particular, a `do` block in Julia looks like this:
```
map([A, B, C]) do x
    if x < 0 && iseven(x)
        return 0
    elseif x == 0
        return 1
    else
        return x
    end
end
```
and where the `x` is, only an identifier (and not an interpolation expression) can appear. This means we cannot currently parse a program that has a metavariable in that position.

There's a few things we could do:
1) try to make `identifier` match a Semgrep metavariable regex. This causes an issue, because Julia interpolation expressions can be lowercase. This means something like this `$Pack` can parse as two things, a `$P` corresponding to a metavariable, and then a `ack`, which is a Julia identifier. This then causes a parsing issue.
One thing we can do to fix that is to use a word boundary regex, which will only end the token at the boundary of a word. This would be nice, but `tree-sitter` does not support word boundary assertions: https://github.com/tree-sitter/tree-sitter/blob/62e96c9f61af086641699a8848cf881d27e9afdf/cli/src/generate/prepare_grammar/expand_tokens.rs#L255
EDIT: this was only a problem prior to discovering Solution 3, where we can actually make `identifier` a proper nonterminal.
2) We could try to be more permissive, and simply allow an `identifier` to be a superset of `interpolation_expression`s, and fix it at Generic translation time. One way of doing this is to change `identifier` to be:
```
    // Metavariables
    identifier: ($, previous) => {
      return token(
        choice(
          previous,
          token.immediate(seq("$", previous))
        ));
    },
```
which would simply enhance `identifier`s to make `$` followed by an ident still an ident, which could be translated to the proper constructs in Semgrep itself, if it does not exactly match our Semgrep metavariable regex criteria.

The problem is that this changes the parse tree. This causes us to fail `tree-sitter test`, because we produce a parse tree where we parse an `identifier`, where it used to be an `interpolation_expression`. We currently have no way of doing fine-grained test manipulation behavior, because we just import the tests from the original grammar and run `tree-sitter test` as a monolith. This means our CI would fail, `test-lang` would fail, and it's not something we're ready to amend.

We could try to prefer to parse as an `interpolation_expression`, but this presents difficulties with the precedences, because `identifier` is a token and also the word token (which cannot be a nonterminal), and just in general I think this process becomes unmaintainable, because our `identifier` is now too permissive.

3) Another approach is to make `identifier` possibly a `choice` of a Semgrep metavariable regex. This would ordinarily be possible, with the exception of the fact that the `identifier` symbol is actually also what is known as the _word token_ in `tree-sitter` ( see https://tree-sitter.github.io/tree-sitter/creating-parsers#keyword-extraction ). This is coded in the logic of `tree-sitter` to be unable to be a nonterminal, meaning that it is impossible to augment `identifier` with another nonterminal.

I believe it would not be much effort to decouple `identifier` from being the word token, if we can get this merged: https://github.com/tree-sitter/tree-sitter-julia/pull/114

Taking into account that change, this PR becomes the solution. We're still not done at this point, though, because this would cause us to parse `identifier`s even when we could parse an `interpolation_expression`. This might seem desirable from a Semgrep standpoint, except for the fact that we run into the same issue from earlier, where this will change our parse tree. We fix this by simply allowing `interpolation_expression` to be also be a metavariable regex, but with a higher precedence than the `identifier` case. Thus, we should only parse `identifier` from a `semgrep_metavariable` if we cannot also parse an `interpolation_expression`.

## Test plan:
`make test`

Fixes https://github.com/returntocorp/semgrep/issues/8249


### Security

- [X] Change has no security implications (otherwise, ping the security team)
