### PR TITLE
add underscore back to julia metavars

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-julia/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-julia/grammar.js
@@ -29,6 +29,13 @@ module.exports = grammar(base_grammar, {
 
     deep_expression: $ => seq("<...", $._expression, "...>"),
 
+    // Note that this is actually slightly more permissive than a Semgrep
+    // metavariable usually is. This is fine, because having a slightly more
+    // permissive grammar is OK, we will just dispatch in the Generic
+    // translation.
+    semgrep_extended_metavariable: $ =>
+        /\$[A-Z_][a-zA-Z_0-9]*/,
+
     // Metavariables
     // We allow an identifier to be a simple metavariable regex, so that
     // we properly support metavariables.
@@ -37,7 +44,7 @@ module.exports = grammar(base_grammar, {
     identifier: ($, previous) =>
       prec(1, choice(
         previous,
-        /\$[A-Z][a-zA-Z0-9]*/,
+        $.semgrep_extended_metavariable
       )),
 
     // ...But we also allow an interpolation expression to be a metavariable.
@@ -60,7 +67,9 @@ module.exports = grammar(base_grammar, {
       previous,
       // We alias the included metavariable to an $.identifier so that the parse
       // tree stays the same. Otherwise, we will fail `tree-sitter` tests.
-      alias(prec(999, /\$[A-Z][a-zA-Z0-9]*/), $.identifier)
+      alias(prec(999,
+        $.semgrep_extended_metavariable
+        ), $.identifier)
     ),
 
     _expression: ($, previous) => choice(

--- a/lang/semgrep-grammars/src/semgrep-julia/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-julia/test/corpus/semgrep.txt
@@ -200,7 +200,8 @@ using $MODULE: $X as $Y
       (import_alias
         (interpolation_expression
           (identifier))
-        (identifier)))))
+        (identifier
+          (semgrep_extended_metavariable))))))
 
 ================================================================================
 Metavariable in do block
@@ -219,7 +220,8 @@ end
       (vector_expression))
     (do_clause
       (parameter_list
-        (identifier))
+        (identifier
+          (semgrep_extended_metavariable)))
       (return_statement
         (identifier)))))
 


### PR DESCRIPTION
The previous regex for Julia metavars didn't have underscores. Let's fix that.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
