### PR TITLE
feat(c++): augment with semgrep constructs

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-cpp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-cpp/test/corpus/semgrep.txt
@@ -12,6 +12,54 @@ $VAR = 1;
       (number_literal))))
 
 ================================================================================
+Metavariable pattern
+================================================================================
+
+__SEMGREP_EXPRESSION $X
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (identifier)))
+
+================================================================================
+Typed metavariable
+================================================================================
+
+int x = (int* $FOO);
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (parenthesized_expression
+        (semgrep_typed_metavar
+          (type_descriptor
+            (primitive_type)
+            (abstract_pointer_declarator))
+          (semgrep_metavar))))))
+
+================================================================================
+Deep expression operator
+================================================================================
+
+__SEMGREP_EXPRESSION <... foo($E) ...>
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (deep_ellipsis
+      (call_expression
+        (identifier)
+        (argument_list
+          (identifier))))))
+
+================================================================================
 Ellipsis for expression
 ================================================================================
 
@@ -26,6 +74,152 @@ $VAR->$MEMBER = ...;
         (identifier)
         (field_identifier))
       (semgrep_ellipsis))))
+
+================================================================================
+Call with ellipsis
+================================================================================
+
+foo(1, ..., 3);
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expression_statement
+    (call_expression
+      (identifier)
+      (argument_list
+        (number_literal)
+        (semgrep_ellipsis)
+        (number_literal)))))
+
+================================================================================
+Call pattern
+================================================================================
+
+__SEMGREP_EXPRESSION $FUNC(1, ...)
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (call_expression
+      (identifier)
+      (argument_list
+        (number_literal)
+        (semgrep_ellipsis)))))
+
+================================================================================
+Named ellipsis
+================================================================================
+
+int main() {
+  $TY $X = $E;
+  $...STUFF;
+  foo();
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list))
+    (compound_statement
+      (declaration
+        (type_identifier)
+        (init_declarator
+          (identifier)
+          (identifier)))
+      (expression_statement
+        (semgrep_named_ellipsis))
+      (expression_statement
+        (call_expression
+          (identifier)
+          (argument_list))))))
+
+================================================================================
+Method chaining
+================================================================================
+
+__SEMGREP_EXPRESSION foo. ... .bar()
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (call_expression
+      (field_expression
+        (field_expression
+          (identifier)
+          (semgrep_ellipsis))
+        (field_identifier))
+      (argument_list))))
+
+================================================================================
+Block item ellipsis
+================================================================================
+
+int main(int $X) {
+  ...
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (primitive_type)
+          (identifier))))
+    (compound_statement
+      (semgrep_ellipsis))))
+
+================================================================================
+Top level ellipsis
+================================================================================
+
+int x = 2;
+...
+int y = 3;
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (number_literal)))
+  (semgrep_ellipsis)
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (number_literal))))
+
+================================================================================
+Parameter ellipsis
+================================================================================
+
+int m(int $X, ...) { }
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (primitive_type)
+          (identifier))))
+    (compound_statement)))
 
 ================================================================================
 Comma expression
@@ -64,18 +258,39 @@ Fold expressions
       (number_literal))))
 
 ================================================================================
-Call with ellipsis
+Parenthesized multiplication
 ================================================================================
 
-foo(1, ..., 3);
+int x = (x * y);
 
 --------------------------------------------------------------------------------
 
 (translation_unit
-  (expression_statement
-    (call_expression
+  (declaration
+    (primitive_type)
+    (init_declarator
       (identifier)
-      (argument_list
-        (number_literal)
-        (semgrep_ellipsis)
-        (number_literal)))))
+      (parenthesized_expression
+        (binary_expression
+          (identifier)
+          (identifier))))))
+
+================================================================================
+Typed metavariable with pointer
+================================================================================
+
+int x = (x * $Y);
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (parenthesized_expression
+        (semgrep_typed_metavar
+          (type_descriptor
+            (type_identifier)
+            (abstract_pointer_declarator))
+          (semgrep_metavar))))))


### PR DESCRIPTION
This PR augments C++ with Semgrep-specific constructs, as well as an alternate expression-parsing entry point. This is in the hopes that we can deprecate the old Pfff parser for Tree-sitter, which necessitates that we be able to parse patterns.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
